### PR TITLE
Normalize ppc64le to powerpc64le instead of the opposite

### DIFF
--- a/src/PlatformNames.jl
+++ b/src/PlatformNames.jl
@@ -14,8 +14,8 @@ struct Linux <: Platform
         if libc !== :glibc && libc !== :musl
             throw(ArgumentError("Unsupported libc '$libc' for Linux"))
         end
-        if arch === :powerpc64le
-            arch = :ppc64le
+        if arch === :ppc64le
+            arch = :powerpc64le
         end
         new(arch, libc)
     end
@@ -117,7 +117,7 @@ function supported_platforms()
         Linux(:x86_64),
         Linux(:aarch64),
         Linux(:armv7l),
-        Linux(:ppc64le),
+        Linux(:powerpc64le),
         MacOS(),
         Windows(:i686),
         Windows(:x86_64),


### PR DESCRIPTION
The toolchain is `powerpc64le`, so we should normalize to that instead of `ppc64le`.

Fixes https://github.com/JuliaPackaging/BinaryBuilder.jl/issues/21