### PR TITLE
Plug fd leak for windows tests

### DIFF
--- a/src/Prefix.jl
+++ b/src/Prefix.jl
@@ -448,7 +448,7 @@ function verify(path::AbstractString, hash::AbstractString; verbose::Bool = fals
     # First, it must exist
     if isfile(hash_path)
         # Next, it must contain the same hash as what we're verifying against
-        if readstring(open(hash_path, "r")) == hash
+        if read(hash_path, String) == hash
             # Next, it must be no older than the actual path
             if stat(hash_path).mtime >= stat(path).mtime
                 # If all of that is true, then we're good!


### PR DESCRIPTION
Windows CI wasn't happy that we were letting a file descriptor leak here, so let's use do-blocks to ensure that doesn't happen.