### PR TITLE
Add backwards-compatible varname guessers

### DIFF
--- a/src/BackwardsCompat.jl
+++ b/src/BackwardsCompat.jl
@@ -1,0 +1,98 @@
+export @write_deps_file
+
+## Everything in this file can be thrown out once users aren't using the old
+## Product syntax and old @write_deps_file macro anymore.  As of the time of
+## this writing, those packages are:
+##
+##  - EzXML
+##  - CALCEPH
+##  - Sundials
+##  - Snappy
+##
+## Once those packages update, we can drop these shims
+
+# Jam a new variable name into a Product
+function revar_product(p::Product, new_varname)
+    if p isa LibraryProduct
+        return LibraryProduct(p.dir_path, p.libnames, new_varname)
+    elseif p isa ExecutableProduct
+        return ExecutableProduct(p.path, new_varname)
+    elseif p isa FileProduct
+        return FileProduct(p.path, new_varname)
+    else
+        error("Unknown product type $(typeof(p))")
+    end
+end
+
+# Deprecated backwards-compatibility macro
+macro write_deps_file(capture...)
+    # props to @tshort for his macro wizardry
+    names = :($(capture))
+    products = esc(Expr(:tuple, capture...))
+
+    # We have to create this dummy_source, because we cannot, in a single line,
+    # have both `@__FILE__` and `__source__` interpreted by the same julia.
+    dummy_source = VERSION >= v"0.7.0-" ? __source__.file : ""
+
+    # Set this to verbose if we've requested it from build.jl
+    verbose = "--verbose" in ARGS
+
+    return quote
+        warn("@write_deps_file is deprecated, use the function not the macro!")
+        const source = VERSION >= v"0.7.0-" ? $("$(dummy_source)") : @__FILE__
+        const depsjl_path = joinpath(dirname(source), "deps.jl")
+
+        # Insert our macro-captured information
+        names = $(names)
+        products = [p for p in $(products)]
+
+        # Jam the captured names into here as new-style variable names
+        for idx in 1:length(products)
+            products[idx] = revar_product(products[idx], names[idx])
+        end
+
+        # Call the new write_deps_file() function
+        write_deps_file(depsjl_path, products; verbose=$(verbose))
+    end
+end
+
+function guess_varname(path::AbstractString)
+    # Take the basename of the path
+    path = basename(path)
+
+    # Chop off things that can't be part of variable names but are
+    # often part of paths:
+    bad_idxs = findin(path, "-.")
+    if !isempty(bad_idxs)
+        path = path[1:minimum(bad_idxs)-1]
+    end
+
+    # Return this as a Symbol
+    return Symbol(path)
+end
+
+function LibraryProduct(dir_or_prefix, libnames)
+    varname = :unknown
+    if libnames isa Vector
+        varname = guess_varname(libnames[1])
+    elseif libnames isa AbstractString
+        varname = guess_varname(libnames)
+    end
+    warn("LibraryProduct() now takes a variable name! auto-choosing $(varname)")
+    return LibraryProduct(dir_or_prefix, libnames, varname)
+end
+
+function ExecutableProduct(prefix::Prefix, binname::AbstractString)
+    return ExecutableProduct(joinpath(bindir(prefix), binname))
+end
+function ExecutableProduct(binpath::AbstractString)
+    varname = guess_varname(binpath)
+    warn("ExecutableProduct() now takes a variable name!  auto-choosing $(varname)")
+    return ExecutableProduct(binpath, varname)
+end
+
+function FileProduct(path)
+    varname = guess_varname(path)
+    warn("FileProduct() now takes a variable name!  auto-choosing $(varname)")
+    return FileProduct(path, varname)
+end

--- a/src/BinaryProvider.jl
+++ b/src/BinaryProvider.jl
@@ -20,6 +20,9 @@ include("Prefix.jl")
 # Abstraction of "needing" a file, that would trigger an install
 include("Products.jl")
 
+# Backwards-compatibility shims
+include("BackwardsCompat.jl")
+
 function __init__()
     global global_prefix
 

--- a/src/Products.jl
+++ b/src/Products.jl
@@ -1,5 +1,5 @@
 export Product, LibraryProduct, FileProduct, ExecutableProduct, satisfied,
-       locate, write_deps_file, @write_deps_file, variable_name
+       locate, write_deps_file, variable_name
 
 """
 A `Product` is an expected result after building or installation of a package.
@@ -369,90 +369,4 @@ function write_deps_file(depsjl_path::AbstractString,
         # Close the `check_deps()` function
         println(depsjl_file, "end")
     end
-end
-
-function revar_product(p::Product, new_varname)
-    if p isa LibraryProduct
-        return LibraryProduct(p.dir_path, p.libnames, new_varname)
-    elseif p isa ExecutableProduct
-        return ExecutableProduct(p.path, new_varname)
-    elseif p isa FileProduct
-        return FileProduct(p.path, new_varname)
-    else
-        error("Unknown product type $(typeof(p))")
-    end
-end
-
-# Deprecated backwards-compatibility macro
-macro write_deps_file(capture...)
-    # props to @tshort for his macro wizardry
-    names = :($(capture))
-    products = esc(Expr(:tuple, capture...))
-
-    # We have to create this dummy_source, because we cannot, in a single line,
-    # have both `@__FILE__` and `__source__` interpreted by the same julia.
-    dummy_source = VERSION >= v"0.7.0-" ? __source__.file : ""
-
-    # Set this to verbose if we've requested it from build.jl
-    verbose = "--verbose" in ARGS
-
-    return quote
-        warn("@write_deps_file is deprecated, use the function not the macro!")
-        const source = VERSION >= v"0.7.0-" ? $("$(dummy_source)") : @__FILE__
-        const depsjl_path = joinpath(dirname(source), "deps.jl")
-
-        # Insert our macro-captured information
-        names = $(names)
-        products = [p for p in $(products)]
-
-        # Jam the captured names into here as new-style variable names
-        for idx in 1:length(products)
-            products[idx] = revar_product(products[idx], names[idx])
-        end
-
-        # Call the new write_deps_file() function
-        write_deps_file(depsjl_path, products; verbose=$(verbose))
-    end
-end
-
-function guess_varname(path::AbstractString)
-    # Take the basename of the path
-    path = basename(path)
-
-    # Chop off things that can't be part of variable names but are
-    # often part of paths:
-    bad_idxs = findin(path, "-.")
-    if !isempty(bad_idxs)
-        path = path[1:minimum(bad_idxs)-1]
-    end
-
-    # Return this as a Symbol
-    return Symbol(path)
-end
-
-# Define some deprecation warnings for users that haven't updated their syntax
-function LibraryProduct(dir_or_prefix, libnames)
-    varname = :unknown
-    if libnames isa Vector
-        varname = guess_varname(libnames[1])
-    elseif libnames isa AbstractString
-        varname = guess_varname(libnames)
-    end
-    warn("LibraryProduct() now takes a variable name! auto-choosing $(varname)")
-    return LibraryProduct(dir_or_prefix, libnames, varname)
-end
-
-function ExecutableProduct(prefix::Prefix, binname::AbstractString)
-    return ExecutableProduct(joinpath(bindir(prefix), binname))
-end
-function ExecutableProduct(binpath::AbstractString)
-    varname = guess_varname(binpath)
-    warn("ExecutableProduct() now takes a variable name!  auto-choosing $(varname)")
-    return ExecutableProduct(binpath, varname)
-end
-
-function FileProduct(path)
-    varname = guess_varname(path)
-    warn("FileProduct() now takes a variable name!  auto-choosing $(varname)")
-    return FileProduct(path, varname)
 end

--- a/src/Products.jl
+++ b/src/Products.jl
@@ -1,5 +1,5 @@
 export Product, LibraryProduct, FileProduct, ExecutableProduct, satisfied,
-       locate, write_deps_file, variable_name
+       locate, write_deps_file, @write_deps_file, variable_name
 
 """
 A `Product` is an expected result after building or installation of a package.
@@ -312,8 +312,10 @@ function write_deps_file(depsjl_path::AbstractString,
     """)
 
     # Begin by ensuring that we can satisfy every product RIGHT NOW
-    if any(.!(satisfied.(products; verbose=verbose)))
-        error("$product is not satisfied, cannot generate deps.jl!")
+    for p in products
+        if !satisfied(p; verbose=verbose)
+            error("$p is not satisfied, cannot generate deps.jl!")
+        end
     end
 
     # If things look good, let's generate the `deps.jl` file
@@ -369,6 +371,49 @@ function write_deps_file(depsjl_path::AbstractString,
     end
 end
 
+function revar_product(p::Product, new_varname)
+    if p isa LibraryProduct
+        return LibraryProduct(p.dir_path, p.libnames, new_varname)
+    elseif p isa ExecutableProduct
+        return ExecutableProduct(p.path, new_varname)
+    elseif p isa FileProduct
+        return FileProduct(p.path, new_varname)
+    else
+        error("Unknown product type $(typeof(p))")
+    end
+end
+
+# Deprecated backwards-compatibility macro
+macro write_deps_file(capture...)
+    # props to @tshort for his macro wizardry
+    names = :($(capture))
+    products = esc(Expr(:tuple, capture...))
+
+    # We have to create this dummy_source, because we cannot, in a single line,
+    # have both `@__FILE__` and `__source__` interpreted by the same julia.
+    dummy_source = VERSION >= v"0.7.0-" ? __source__.file : ""
+
+    # Set this to verbose if we've requested it from build.jl
+    verbose = "--verbose" in ARGS
+
+    return quote
+        warn("@write_deps_file is deprecated, use the function not the macro!")
+        const source = VERSION >= v"0.7.0-" ? $("$(dummy_source)") : @__FILE__
+        const depsjl_path = joinpath(dirname(source), "deps.jl")
+
+        # Insert our macro-captured information
+        names = $(names)
+        products = [p for p in $(products)]
+
+        # Jam the captured names into here as new-style variable names
+        for idx in 1:length(products)
+            products[idx] = revar_product(products[idx], names[idx])
+        end
+
+        # Call the new write_deps_file() function
+        write_deps_file(depsjl_path, products; verbose=$(verbose))
+    end
+end
 
 function guess_varname(path::AbstractString)
     # Take the basename of the path

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -632,3 +632,19 @@ end
         end
     end
 end
+
+# Test that our deprecations are working
+@testset "Deprecations" begin
+    temp_prefix() do prefix
+        # Test that basic satisfication is not guaranteed
+        e_path = joinpath(bindir(prefix), "fooifier")
+        l_path = joinpath(libdir(prefix), "libfoo.$(Libdl.dlext)")
+        e = ExecutableProduct(prefix, "fooifier")
+        ef = FileProduct(e_path)
+        l = LibraryProduct(prefix, "libfoo")
+
+        @test variable_name(e) == "fooifier"
+        @test variable_name(ef) == "fooifier"
+        @test variable_name(l) == "libfoo"
+    end
+end


### PR DESCRIPTION
Also adds backward-compatible `@write_deps_file` macro.  Will warn users to upgrade, but won't kill packages that have been using `BinaryProvider.jl` so far.  Gotta keep the customers happy!