### PR TITLE
Ensure that `install()` passes `force` through to `download_verify()`

### DIFF
--- a/src/Prefix.jl
+++ b/src/Prefix.jl
@@ -277,7 +277,8 @@ function install(tarball_url::AbstractString,
         verify(tarball_path, hash; verbose=verbose)
     else
         # If not, actually download it
-        download_verify(tarball_url, hash, tarball_path; verbose=verbose)
+        download_verify(tarball_url, hash, tarball_path;
+                        force=force, verbose=verbose)
     end
 
     if verbose

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -612,6 +612,8 @@ const libfoo_downloads = Dict(
 
             @test_throws ErrorException install(url, hash; prefix=prefix, verbose=true)
             @test install(url, hash; prefix=prefix, verbose=true, force=true)
+            @test satisfied(fooifier; verbose=true)
+            @test satisfied(libfoo; verbose=true)
         end
 
         # Test a bad download fails properly

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -593,7 +593,7 @@ const libfoo_downloads = Dict(
             sleep(2)
 
             open(tmpfile, "w") do f
-                write(f, "hehehehe")
+                write(f, "not the correct contents")
             end
 
             @test_throws ErrorException download_verify(url, hash, tmpfile; verbose=true)
@@ -601,6 +601,17 @@ const libfoo_downloads = Dict(
             # This should return `false`, signifying that the download had to erase
             # the previously downloaded file.
             @test !download_verify(url, hash, tmpfile; verbose=true, force=true)
+
+            # Now let's test that install() works the same way; freaking out if
+            # the local path has been messed with, unless `force` has been given:
+            tarball_path = joinpath(prefix, "downloads", basename(url))
+            try mkpath(dirname(tarball_path)) end
+            open(tarball_path, "w") do f
+                write(f, "not the correct contents")
+            end
+
+            @test_throws ErrorException install(url, hash; prefix=prefix, verbose=true)
+            @test install(url, hash; prefix=prefix, verbose=true, force=true)
         end
 
         # Test a bad download fails properly


### PR DESCRIPTION
This ensures that `install(... ;force=true)` will happily overwrite old tarballs within `$(prefix)/downloads`.