### PR TITLE
Add `repr()` methods to all `Products`

### DIFF
--- a/src/OutputCollector.jl
+++ b/src/OutputCollector.jl
@@ -3,7 +3,7 @@
 # intelligently after the fact, or keep them separate for proper analysis.
 import Base: wait, merge
 
-export OutputCollector, merge, stdout, stderr, tail, tee
+export OutputCollector, merge, collect_stdout, collect_stderr, tail, tee
 
 struct LineStream
     pipe::Pipe
@@ -235,20 +235,20 @@ function merge(collector::OutputCollector; colored::Bool = false)
 end
 
 """
-`stdout(collector::OutputCollector)`
+    collect_stdout(collector::OutputCollector)
 
 Returns all stdout lines collected by this collector so far.
 """
-function stdout(collector::OutputCollector)
+function collect_stdout(collector::OutputCollector)
     return join([l[2] for l in collector.stdout_linestream.lines], "")
 end
 
 """
-`stderr(collector::OutputCollector)`
+    collect_stderr(collector::OutputCollector)
 
 Returns all stderr lines collected by this collector so far.
 """
-function stderr(collector::OutputCollector)
+function collect_stderr(collector::OutputCollector)
     return join([l[2] for l in collector.stderr_linestream.lines], "")
 end
 

--- a/src/Prefix.jl
+++ b/src/Prefix.jl
@@ -419,7 +419,7 @@ function list_tarball_files(path::AbstractString; verbose::Bool = false)
     catch
         error("Could not list contents of tarball $(path)")
     end
-    return parse_tarball_listing(stdout(oc))
+    return parse_tarball_listing(collect_stdout(oc))
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -67,8 +67,8 @@ end
         end
 
         # Test that we can grab stdout and stderr separately
-        @test stdout(oc) == "1\n3\n4\n"
-        @test stderr(oc) == "2\n"
+        @test collect_stdout(oc) == "1\n3\n4\n"
+        @test collect_stderr(oc) == "2\n"
     end
 
     # Next test a much longer output program
@@ -95,7 +95,7 @@ end
             oc = OutputCollector(sh(`./kill.sh`))
 
             @test !wait(oc)
-            @test stdout(oc) == "1\n2\n"
+            @test collect_stdout(oc) == "1\n2\n"
         end
     end
 
@@ -111,7 +111,7 @@ end
         oc = OutputCollector(sh(`./newlines.sh`))
 
         @test wait(oc)
-        @test stdout(oc) == newlines_out
+        @test collect_stdout(oc) == newlines_out
     end
 
     # Next, test that tee'ing to a stream works

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -264,7 +264,7 @@ end
         e_path = joinpath(bindir(prefix), "fooifier")
         l_path = joinpath(libdir(prefix), "libfoo.$(Libdl.dlext)")
         e = ExecutableProduct(prefix, "fooifier", :fooifier)
-        ef = FileProduct(e_path, :fooifier)
+        ef = FileProduct(prefix, joinpath("bin", "fooifier"), :fooifier)
         l = LibraryProduct(prefix, "libfoo", :libfoo)
         lf = FileProduct(l_path, :libfoo)
 
@@ -346,6 +346,25 @@ end
             touch(l_path)
             @test !satisfied(l; verbose=true, platform=foreign_platform)
         end
+    end
+
+    # Test for proper repr behavior
+    temp_prefix() do prefix
+        l = LibraryProduct(prefix, "libfoo", :libfoo)
+        @test repr(l) == "LibraryProduct(prefix, $(repr(["libfoo"])), :libfoo)"
+        l = LibraryProduct(libdir(prefix), ["libfoo", "libfoo2"], :libfoo)
+        @test repr(l) == "LibraryProduct($(repr(libdir(prefix))), $(repr(["libfoo", "libfoo2"])), :libfoo)"
+
+        e = ExecutableProduct(prefix, "fooifier", :fooifier)
+        @test repr(e) == "ExecutableProduct(prefix, \"fooifier\", :fooifier)"
+        e = ExecutableProduct(joinpath(bindir(prefix), "fooifier"), :fooifier)
+        @test repr(e) == "ExecutableProduct($(repr(joinpath(bindir(prefix), "fooifier"))), :fooifier)"
+
+        f = FileProduct(prefix, joinpath("etc", "fooifier"), :foo_conf)
+        @test repr(f) == "FileProduct(prefix, $(repr(joinpath("etc", "fooifier"))), :foo_conf)"
+
+        f = FileProduct(joinpath(prefix, "etc", "foo.conf"), :foo_conf)
+        @test repr(f) == "FileProduct($(repr(joinpath(prefix, "etc", "foo.conf"))), :foo_conf)"
     end
 end
 


### PR DESCRIPTION
This will eventually simplify `BinaryBuilder` such that it doesn't have
to worry about how to actually represent a `Product` faithfully.