### PR TITLE
add isinstalled and install(clean=true)

### DIFF
--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -447,7 +447,7 @@ match the given `hash`.
 
 This method returns `true` if the file was downloaded successfully, `false`
 if an existing file was removed due to the use of `force`, and throws an error
-if `force` is not set and the already-existant file fails verification, or if
+if `force` is not set and the already-existent file fails verification, or if
 `force` is set, verification fails, and then verification fails again after
 redownloading the file.
 
@@ -569,7 +569,7 @@ function unpack(tarball_path::AbstractString, dest::AbstractString;
     # unpack into dest
     mkpath(dest)
     oc = OutputCollector(gen_unpack_cmd(tarball_path, dest); verbose=verbose)
-    try 
+    try
         if !wait(oc)
             error()
         end

--- a/src/Prefix.jl
+++ b/src/Prefix.jl
@@ -248,13 +248,12 @@ function isinstalled(tarball_url::AbstractString, hash::AbstractString;
     if safe_isfile(tarball_url)
         tarball_path = tarball_url
     end
-    isfile(tarball_path) || return false
-    isfile(hash_path) || return false
-    read(hash_path, String) == hash || return false
+    try
+        verify(tarball_path, hash; verbose=false, hash_path=hash_path)
+    catch
+        return false
+    end
     tarball_time = stat(tarball_path).mtime
-    stat(hash_path).mtime >= tarball_time || return false
-    # verify(...) doesn't re-hash if the hashfile matches, so we won't either
-    # bytes2hex(open(sha256, tarball_path)) == hash || return false
 
     # check that manifest and the files listed within it exist
     # and are at least as new as the tarball.

--- a/src/Prefix.jl
+++ b/src/Prefix.jl
@@ -284,7 +284,7 @@ function isinstalled(tarball_url::AbstractString, hash::AbstractString;
         return false
     end
     for installed_file in joinpath.(prefix, chomp.(readlines(manifest_path)))
-        if !isfile(installed_file) || stat(installed_file).ctime < tarball_time
+        if !isfile(installed_file) && !islink(installed_file)
             verbose && Compat.@info("$installed_file not found")
             return false
         end

--- a/src/Prefix.jl
+++ b/src/Prefix.jl
@@ -274,7 +274,6 @@ end
             hash::AbstractString;
             prefix::Prefix = global_prefix,
             force::Bool = false,
-            clean::Bool = false,
             ignore_platform::Bool = false,
             verbose::Bool = false)
 
@@ -283,9 +282,9 @@ prefix, verify its integrity with the `hash`, and install it into the `prefix`.
 Also save a manifest of the files into the prefix for uninstallation later.
 
 This will not overwrite any files within `prefix` unless `force=true` is set.
-If `clean=true` is set, then any files previously installed for `tarball_url`
-(as listed in an pre-existing manifest), if any, are deleted before installing
-files from the downloaded tarball.
+If `force=true` is set, installation will overwrite files as needed, and it
+will also delete any files previously installed for `tarball_url`
+as listed in a pre-existing manifest (if any).
 
 By default, this will not install a tarball that does not match the platform of
 the current host system, this can be overridden by setting `ignore_platform`.
@@ -294,7 +293,6 @@ function install(tarball_url::AbstractString,
                  hash::AbstractString;
                  prefix::Prefix = global_prefix,
                  force::Bool = false,
-                 clean::Bool = false,
                  ignore_platform::Bool = false,
                  verbose::Bool = false)
     # If we're not ignoring the platform, get the platform key from the tarball
@@ -345,9 +343,9 @@ function install(tarball_url::AbstractString,
         Compat.@info("Installing $(tarball_path) into $(prefix.path)")
     end
 
-    # remove old files if clean=true
+    # remove old files if force=true
     manifest_path = manifest_from_url(tarball_url, prefix=prefix)
-    clean && isfile(manifest_path) && uninstall(manifest_path, verbose=verbose)
+    force && isfile(manifest_path) && uninstall(manifest_path, verbose=verbose)
 
     # First, get list of files that are contained within the tarball
     file_list = list_tarball_files(tarball_path)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -690,7 +690,6 @@ const libfoo_downloads = Dict(
 
             @test_throws ErrorException install(url, hash; prefix=prefix, verbose=true)
             @test install(url, hash; prefix=prefix, verbose=true, force=true)
-            @test install(url, hash; prefix=prefix, verbose=true, clean=true)
             @test isinstalled(url, hash; prefix=prefix)
             @test satisfied(fooifier; verbose=true)
             @test satisfied(libfoo; verbose=true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -690,7 +690,6 @@ const libfoo_downloads = Dict(
 
             @test_throws ErrorException install(url, hash; prefix=prefix, verbose=true)
             @test install(url, hash; prefix=prefix, verbose=true, force=true)
-            @test_throws ErrorException install(url, hash; prefix=prefix, verbose=true)
             @test install(url, hash; prefix=prefix, verbose=true, clean=true)
             @test isinstalled(url, hash; prefix=prefix)
             @test satisfied(fooifier; verbose=true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -491,7 +491,7 @@ end
         @test_throws ErrorException install(tarball_path, tarball_hash; prefix=prefix)
 
         # Ensure we can uninstall this tarball
-        @test isinstalled(tarball_path, tarball_hash; prefix=prefix, verbose=true)
+        @test isinstalled(tarball_path, tarball_hash; prefix=prefix)
         Base.rm(bar_path)
         @test !isinstalled(tarball_path, tarball_hash; prefix=prefix)
         @test uninstall(manifest_path; verbose=true)


### PR DESCRIPTION
This PR adds an `isinstalled(url, hash)` function that checks whether the given `url` has already been installed.  Closes #59 — once this is merged and tagged, I can submit a PR to BinaryBuilder that changes the default `build.jl` to check `isinstalled`.

It also ~~adds a `clean=true` option to `install(...)` that calls~~ makes `install(...,force=true)` call `uninstall` on a pre-existing manifest file if one exists.

Finally, I noticed that `install(path)` (i.e. called with a filename argument, not a URL) would write to `path.sha256`, which seemed problematic: what if you are installing from a read-only location?  So, I changed it to always write the hash file into `<prefix>/downloads`.