### PR TITLE
Map amd64 and i386 on FreeBSD

### DIFF
--- a/src/PlatformNames.jl
+++ b/src/PlatformNames.jl
@@ -353,7 +353,7 @@ function platform_key(machine::AbstractString = Sys.MACHINE)
         end
     end
 
-    warn("Platform `$(machine)` is not an officially supported platform")
+    Compat.@warn("Platform `$(machine)` is not an officially supported platform")
     return UnknownPlatform()
 end
 

--- a/src/PlatformNames.jl
+++ b/src/PlatformNames.jl
@@ -285,7 +285,7 @@ the use of the `machine` parameter.
 function platform_key(machine::AbstractString = Sys.MACHINE)
     # We're going to build a mondo regex here to parse everything:
     arch_mapping = Dict(
-        :x86_64 => "x86_64",
+        :x86_64 => "(x86_|amd)64",
         :i686 => "i\\d86",
         :aarch64 => "aarch64",
         :armv7l => "arm(v7l)?",

--- a/src/PlatformNames.jl
+++ b/src/PlatformNames.jl
@@ -105,11 +105,19 @@ struct FreeBSD <: Platform
 
     function FreeBSD(arch::Symbol, libc::Symbol=:blank_libc,
                                    abi::Symbol=:default_abi)
-        if !in(arch, [:i686, :x86_64, :aarch64, :powerpc64le, :armv7l])
+        # `uname` on FreeBSD reports its architecture as amd64 and i386 instead of x86_64
+        # and i686, respectively. In the off chance that Julia hasn't done the mapping for
+        # us, we'll do it here just in case.
+        if arch === :amd64
+            arch = :x86_64
+        elseif arch === :i386
+            arch = :i686
+        elseif !in(arch, [:i686, :x86_64, :aarch64, :powerpc64le, :armv7l])
             throw(ArgumentError("Unsupported architecture '$arch' for FreeBSD"))
         end
 
-        # The only libc we support on FreeBSD is the blank libc
+        # The only libc we support on FreeBSD is the blank libc, which corresponds to
+        # FreeBSD's default libc
         if libc !== :blank_libc
             throw(ArgumentError("Unsupported libc '$libc' for FreeBSD"))
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -118,7 +118,7 @@ end
         oc = OutputCollector(sh(`./simple.sh`); tee_stream=ios, verbose=true)
         @test wait(oc)
         @test merge(oc) == simple_out
-        
+
         seekstart(ios)
         tee_out = String(read(ios))
         tee_out = strip_colorization(tee_out)
@@ -147,7 +147,7 @@ end
 
         @test !wait(oc)
         @test merge(oc) == "1\n2\n"
-        
+
         seekstart(ios)
         @test String(read(ios)) == ""
     end
@@ -176,7 +176,9 @@ end
     @test arch(Linux(:aarch64, :musl)) == :aarch64
     @test arch(Windows(:i686)) == :i686
     @test arch(UnknownPlatform()) == :unknown
- 
+    @test arch(FreeBSD(:amd64)) == :x86_64
+    @test arch(FreeBSD(:i386)) == :i686
+
     # Test that our platform_dlext stuff works
     @test platform_dlext(Linux(:x86_64)) == platform_dlext(Linux(:i686))
     @test platform_dlext(Windows(:x86_64)) == platform_dlext(Windows(:i686))
@@ -205,6 +207,8 @@ end
     @test platform_key("i686-w64-mingw32") == Windows(:i686)
     @test platform_key("x86_64-unknown-freebsd11.1") == FreeBSD(:x86_64)
     @test platform_key("i686-unknown-freebsd11.1") == FreeBSD(:i686)
+    @test platform_key("amd64-unknown-freebsd12.0") == FreeBSD(:x86_64)
+    @test platform_key("i386-unknown-freebsd10.3") == FreeBSD(:i686)
 
     # Make sure some of these things are rejected
     @test platform_key("totally FREEFORM text!!1!!!1!") == UnknownPlatform()
@@ -611,7 +615,7 @@ const libfoo_downloads = Dict(
 # Test manually downloading and using libfoo
 @testset "Downloading" begin
     temp_prefix() do prefix
-        foo_path = joinpath(prefix,"foo") 
+        foo_path = joinpath(prefix,"foo")
         touch(foo_path)
         # Quick one-off tests for `safe_isfile()`:
         @test BinaryProvider.safe_isfile(foo_path)


### PR DESCRIPTION
`uname` on FreeBSD uses `amd64` instead of `x86_64` and `i386` instead of `i686`. Julia does this mapping on 0.7 but I don't think it does on 0.6, so I figured it was worth adding a trivial bit of logic to handle those cases here just in case.

I've also fixed a deprecation warning on 0.7.