### PR TITLE
Override `show()` for platform objects

### DIFF
--- a/src/PlatformNames.jl
+++ b/src/PlatformNames.jl
@@ -1,5 +1,6 @@
 export platform_key, platform_dlext, valid_dl_path, arch, wordsize, triplet,
        Platform, UnknownPlatform, Linux, MacOS, Windows, FreeBSD
+import Base: show
 
 abstract type Platform end
 
@@ -146,6 +147,18 @@ struct FreeBSD <: Platform
         return new(arch, libc, abi)
     end
 end
+
+"""
+    platform_name(p::Platform)
+
+Get the "platform name" of the given platform.  E.g. returns "Linux" for a
+`Linux` object, or "Windows" for a `Windows` object.
+"""
+platform_name(p::Linux) = "Linux"
+platform_name(p::MacOS) = "MacOS"
+platform_name(p::Windows) = "Windows"
+platform_name(p::FreeBSD) = "FreeBSD"
+platforn_name(p::UnknownPlatform) = "UnknownPlatform"
 
 """
     arch(p::Platform)
@@ -374,4 +387,23 @@ function valid_dl_path(path::AbstractString, platform::Platform)
 
     # Return whether or not that regex matches the basename of the given path
     return ismatch(dlregex, basename(path))
+end
+
+
+# Define show() for these objects for two reasons:
+#  - I don't like the `BinaryProvider.` at the beginning of the types;
+#    it's unnecessary as these are exported
+#  - I don't like the :blank_* arguments, they're unnecessary
+function show(io::IO, p::Platform)
+    write(io, "$(platform_name(p))($(repr(arch(p)))")
+    omit_libc = libc(p) == :blank_libc
+    omit_abi = abi(p) == :blank_abi
+
+    if !omit_libc || !omit_abi
+        write(io, ", $(repr(libc(p)))")
+    end
+    if !omit_abi
+        write(io, ", $(repr(abi(p)))")
+    end
+    write(io, ")")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -242,6 +242,10 @@ end
     @test triplet(FreeBSD(:x86_64)) == "x86_64-unknown-freebsd11.1"
     @test triplet(FreeBSD(:i686)) == "i686-unknown-freebsd11.1"
     @test triplet(UnknownPlatform()) == "unknown-unknown-unknown"
+
+    @test repr(Windows(:x86_64)) == "Windows(:x86_64)"
+    @test repr(Linux(:x86_64, :glibc, :blank_abi)) == "Linux(:x86_64, :glibc)"
+    @test repr(MacOS()) == "MacOS(:x86_64)"
 end
 
 @testset "Prefix" begin


### PR DESCRIPTION
This will cut down on the verbosity of generated `build.jl` files a fair
bit, which in my humble opinion is a Very Good Thing (TM)