### PR TITLE
Add `tarball_path` kwarg to `install()`

### DIFF
--- a/src/Prefix.jl
+++ b/src/Prefix.jl
@@ -301,6 +301,8 @@ the current host system, this can be overridden by setting `ignore_platform`.
 function install(tarball_url::AbstractString,
                  hash::AbstractString;
                  prefix::Prefix = global_prefix,
+                 tarball_path::AbstractString =
+                     joinpath(prefix, "downloads", basename(tarball_url)),
                  force::Bool = false,
                  ignore_platform::Bool = false,
                  verbose::Bool = false)
@@ -332,7 +334,6 @@ function install(tarball_url::AbstractString,
     end
 
     # Create the downloads directory if it does not already exist
-    tarball_path = joinpath(prefix, "downloads", basename(tarball_url))
     try mkpath(dirname(tarball_path)) end
 
     # Check to see if we're "installing" from a file

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -698,6 +698,22 @@ const libfoo_downloads = Dict(
             @test isinstalled(url, hash; prefix=prefix)
             @test satisfied(fooifier; verbose=true)
             @test satisfied(libfoo; verbose=true)
+
+            # Test that installing with a custom tarball_path works:
+            tarball_path = joinpath(prefix, "downloads2", "tarball.tar.gz")
+            @test install(url, hash; prefix=prefix, tarball_path=tarball_path, verbose=true, force=true)
+
+            # Check that the tarball exists and hashes properly
+            @test isfile(tarball_path)
+            hash_check = open(tarball_path, "r") do f
+                bytes2hex(sha256(f))
+            end
+            @test hash_check == hash
+
+            # Check that we're still satisfied
+            @test isinstalled(url, hash; prefix=prefix)
+            @test satisfied(fooifier; verbose=true)
+            @test satisfied(libfoo; verbose=true)
         end
 
         # Test a bad download fails properly


### PR DESCRIPTION
This allows the user to manually specify a location for downloads to be
cached.  This is useful so that dependencies can be properly cached when
doing lots of `BinaryBuilder` runs.