### PR TITLE
Fix LibraryProducts not finding windows libraries

### DIFF
--- a/src/Prefix.jl
+++ b/src/Prefix.jl
@@ -129,13 +129,13 @@ function bindir(prefix::Prefix)
 end
 
 """
-    libdir(prefix::Prefix)
+    libdir(prefix::Prefix, platform = platform_key())
 
-Returns the library directory for the given `prefix` (not ethat this differs
+Returns the library directory for the given `prefix` (note that this differs
 between unix systems and windows systems).
 """
-function libdir(prefix::Prefix)
-    @static if Compat.Sys.iswindows()
+function libdir(prefix::Prefix, platform = platform_key())
+    if Compat.Sys.iswindows(platform)
         return joinpath(prefix, "bin")
     else
         return joinpath(prefix, "lib")

--- a/src/Products.jl
+++ b/src/Products.jl
@@ -129,7 +129,7 @@ on foreign platforms.
 """
 function locate(lp::LibraryProduct; verbose::Bool = false,
                 platform::Platform = platform_key(), isolate::Bool = false)
-    dir_path = coalesce(lp.dir_path, libdir(lp.prefix, platform))
+    dir_path = something(lp.dir_path, libdir(lp.prefix, platform))
 
     if !isdir(dir_path)
         if verbose

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -347,16 +347,20 @@ end
         # But if it is from a different platform, simple existence will be
         # enough to satisfy a LibraryProduct
         @static if Compat.Sys.iswindows()
-            l_path = joinpath(libdir(prefix), "libfoo.so")
+            l_path = joinpath(libdir(prefix, Linux(:x86_64)), "libfoo.so")
             touch(l_path)
             @test satisfied(l, verbose=true, platform=Linux(:x86_64))
             @test satisfied(l, verbose=true, platform=Linux(:x86_64), isolate=true)
         else
-            l_path = joinpath(libdir(prefix), "libfoo.dll")
+            l_path = joinpath(libdir(prefix, Windows(:x86_64)), "libfoo.dll")
             touch(l_path)
             @test satisfied(l, verbose=true, platform=Windows(:x86_64))
             @test satisfied(l, verbose=true, platform=Windows(:x86_64), isolate=true)
         end
+
+        # Test that we can control libdir() via platform arguments
+        @test libdir(prefix, Linux(:x86_64)) == joinpath(prefix, "lib")
+        @test libdir(prefix, Windows(:x86_64)) == joinpath(prefix, "bin")
     end
 
     # Ensure that the test suite thinks that these libraries are foreign

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -380,7 +380,7 @@ end
     # Test for valid library name permutations
     for ext in ["1.so", "so", "so.1", "so.1.2", "so.1.2.3"]
         temp_prefix() do prefix
-            l_path = joinpath(libdir(prefix), "libfoo.$ext")
+            l_path = joinpath(libdir(prefix, foreign_platform), "libfoo.$ext")
             l = LibraryProduct(prefix, "libfoo", :libfoo)
             mkdir(dirname(l_path))
             touch(l_path)
@@ -391,7 +391,7 @@ end
     # Test for invalid library name permutations
     for ext in ["so.1.2.3a", "so.1.a"]
         temp_prefix() do prefix
-            l_path = joinpath(libdir(prefix), "libfoo.$ext")
+            l_path = joinpath(libdir(prefix, foreign_platform), "libfoo.$ext")
             l = LibraryProduct(prefix, "libfoo", :libfoo)
             mkdir(dirname(l_path))
             touch(l_path)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -293,6 +293,10 @@ end
         deactivate(prefix)
         @test BinaryProvider.split_PATH()[1] != bindir(prefix)
         @test Libdl.DL_LOAD_PATH[1] != libdir(prefix)
+        
+        # Test that we can control libdir() via platform arguments
+        @test libdir(prefix, Linux(:x86_64)) == joinpath(prefix, "lib")
+        @test libdir(prefix, Windows(:x86_64)) == joinpath(prefix, "bin")
     end
 end
 
@@ -347,20 +351,20 @@ end
         # But if it is from a different platform, simple existence will be
         # enough to satisfy a LibraryProduct
         @static if Compat.Sys.iswindows()
-            l_path = joinpath(libdir(prefix, Linux(:x86_64)), "libfoo.so")
+            p = Linux(:x86_64)
+            mkpath(libdir(prefix, p))
+            l_path = joinpath(libdir(prefix, p), "libfoo.so")
             touch(l_path)
-            @test satisfied(l, verbose=true, platform=Linux(:x86_64))
-            @test satisfied(l, verbose=true, platform=Linux(:x86_64), isolate=true)
+            @test satisfied(l, verbose=true, platform=p)
+            @test satisfied(l, verbose=true, platform=p, isolate=true)
         else
-            l_path = joinpath(libdir(prefix, Windows(:x86_64)), "libfoo.dll")
+            p = Windows(:x86_64)
+            mkpath(libdir(prefix, p))
+            l_path = joinpath(libdir(prefix, p), "libfoo.dll")
             touch(l_path)
-            @test satisfied(l, verbose=true, platform=Windows(:x86_64))
-            @test satisfied(l, verbose=true, platform=Windows(:x86_64), isolate=true)
+            @test satisfied(l, verbose=true, platform=p)
+            @test satisfied(l, verbose=true, platform=p, isolate=true)
         end
-
-        # Test that we can control libdir() via platform arguments
-        @test libdir(prefix, Linux(:x86_64)) == joinpath(prefix, "lib")
-        @test libdir(prefix, Windows(:x86_64)) == joinpath(prefix, "bin")
     end
 
     # Ensure that the test suite thinks that these libraries are foreign


### PR DESCRIPTION
Previously, we would create a `LibraryProduct`, which would immediately canonicalize `libdir(prefix)`, which is `/lib` on linux, and wouldn't pay attention to the `platform` we pass in to `satisfied()`.  This fixes that.