### PR TITLE
Fixes for Julia 0.7

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.6
 SHA
-Compat 0.55.0
+Compat 0.67.0

--- a/src/OutputCollector.jl
+++ b/src/OutputCollector.jl
@@ -18,7 +18,7 @@ Given a collection of delimiter characters, read from `s` until one of those
 delimiters is reached, or we reach the end of `s`.
 """
 function readuntil_many(s::IO, delims)
-	out = IOBuffer()
+    out = IOBuffer()
     while !eof(s)
         c = read(s, Char)
         write(out, c)
@@ -59,7 +59,7 @@ function LineStream(pipe::Pipe, event::Condition)
     # This ensures that anybody that's listening to the event but gated on our
     # being alive (e.g. `tee()`) can die alongside us gracefully as well.
     @async begin
-        wait(task)
+        fetch(task)
         notify(event)
     end
     return LineStream(pipe, lines, task)
@@ -155,12 +155,12 @@ function wait(collector::OutputCollector)
     # If we've already done this song and dance before, then don't do it again
     if !collector.done
         wait(collector.P)
-        wait(collector.stdout_linestream.task)
-        wait(collector.stderr_linestream.task)
+        fetch(collector.stdout_linestream.task)
+        fetch(collector.stderr_linestream.task)
 
         # Also fetch on any extra tasks we've jimmied onto the end of this guy
         for t in collector.extra_tasks
-            wait(t)
+            fetch(t)
         end
 
         # From this point on, we are actually done!
@@ -271,7 +271,7 @@ function tail(collector::OutputCollector; len::Int = 100,
     for line_idx in 1:len
         # We can run into UnicodeError's here
         try
-            idx = findprev(equalto('\n'), out, idx-1)
+            idx = findprev(isequal('\n'), out, idx-1)
             # We have to check for both `nothing` or `0` for Julia 0.6
             if idx === nothing || idx == 0
                 idx = 0

--- a/src/PlatformNames.jl
+++ b/src/PlatformNames.jl
@@ -386,7 +386,7 @@ function valid_dl_path(path::AbstractString, platform::Platform)
     dlregex = dlext_regexes[platform_dlext(platform)]
 
     # Return whether or not that regex matches the basename of the given path
-    return ismatch(dlregex, basename(path))
+    return occursin(dlregex, basename(path))
 end
 
 

--- a/src/Prefix.jl
+++ b/src/Prefix.jl
@@ -221,7 +221,7 @@ function extract_platform_key(path::AbstractString)
         path = path[1:end-7]
     end
     # Locate the last - in the path, which will be part of the platform key
-    idx_dash = coalesce(findlast(isequal('-'), path), 0)
+    idx_dash = something(findlast(isequal('-'), path), 0)
     if idx_dash == 0
         Compat.@warn("Could not extract the platform key of $(path); continuing...")
         return platform_key()
@@ -230,7 +230,7 @@ function extract_platform_key(path::AbstractString)
     # backwards from where we found the -. Note that we can't just go looking directly
     # for the ., since there may be a version at the end of the platform key that would
     # get picked up instead, e.g. x86_64-unknown-freebsd11.1.
-    idx_dot = coalesce(findlast(isequal('.'), path[1:idx_dash-1]), 0)
+    idx_dot = something(findlast(isequal('.'), path[1:idx_dash-1]), 0)
     if idx_dot == 0
         Compat.@warn("Could not extract the platform key of $(path); continuing...")
         return platform_key()


### PR DESCRIPTION
In particular, `coalesce` -> `something`, as the former now means something else.