### PR TITLE
Add libdir method in case prefix is nothing

### DIFF
--- a/src/Prefix.jl
+++ b/src/Prefix.jl
@@ -141,6 +141,7 @@ function libdir(prefix::Prefix, platform = platform_key())
         return joinpath(prefix, "lib")
     end
 end
+libdir(::Nothing, platform = platform_key()) = nothing
 
 """
     includedir(prefix::Prefix)


### PR DESCRIPTION
Without this method, it errors on `LibraryProduct` with the directory set explicitly.