### PR TITLE
Add `version` argument to `package()`

### DIFF
--- a/src/Prefix.jl
+++ b/src/Prefix.jl
@@ -619,29 +619,27 @@ function verify(path::AbstractString, hash::AbstractString; verbose::Bool = fals
 end
 
 """
-    package(prefix::Prefix, tarball_base::AbstractString,
-            platform::Platform = platform_key(), verbose::Bool = false)
+    package(prefix::Prefix, output_base::AbstractString,
+            version::VersionNumber;
+            platform::Platform = platform_key(),
+            verbose::Bool = false, force::Bool = false)
 
-Build a tarball of the `prefix`, storing the tarball at `tarball_base` plus a
-platform-dependent suffix and a file extension (defaults to the current
-platform, but overridable through the `platform` argument.  Runs an `audit()`
-on the `prefix`, to ensure that libraries can be `dlopen()`'ed, that all
-dependencies are located within the prefix, etc... See the `audit()`
-documentation for a full list of the audit steps.
-
-Returns the full path to and the hash of the generated tarball.
+Build a tarball of the `prefix`, storing the tarball at `output_base`,
+appending a version number, a platform-dependent suffix and a file extension.
+If no platform is given, defaults to current platform. Runs an `audit()` on the
+`prefix`, to ensure that libraries can be `dlopen()`'ed, that all dependencies
+are located within the prefix, etc... See the `audit()` documentation for a
+full list of the audit steps.  Returns the full path to and hash of the
+generated tarball.
 """
 function package(prefix::Prefix,
-                 tarball_base::AbstractString;
+                 output_base::AbstractString,
+                 version::VersionNumber;
                  platform::Platform = platform_key(),
                  verbose::Bool = false,
                  force::Bool = false)
-    # First calculate the output path given our tarball_base and platform
-    out_path = try
-        "$(tarball_base).$(triplet(platform)).tar.gz"
-    catch
-        error("Platform key `$(platform)` not recognized")
-    end
+    # Calculate output path
+    out_path = "$(output_base).v$(version).$(triplet(platform)).tar.gz"
 
     if isfile(out_path)
         if force
@@ -658,7 +656,7 @@ function package(prefix::Prefix,
         end
     end
 
-    # Package `prefix.path` into the tarball contained at to `out_path`
+    # Package `prefix.path` into the tarball contained at `out_path`
     package(prefix.path, out_path; verbose=verbose)
 
     # Also spit out the hash of the archive file

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -463,7 +463,7 @@ end
         end
 
         # Next, package it up as a .tar.gz file
-        tarball_path, tarball_hash = package(prefix, "./libfoo"; verbose=true)
+        tarball_path, tarball_hash = package(prefix, "./libfoo", v"1.0.0"; verbose=true)
         @test isfile(tarball_path)
 
         # Check that we are calculating the hash properly
@@ -473,7 +473,7 @@ end
         @test tarball_hash_check == tarball_hash
 
         # Test that packaging into a file that already exists fails
-        @test_throws ErrorException package(prefix, "./libfoo")
+        @test_throws ErrorException package(prefix, "./libfoo", v"1.0.0")
     end
 
     # Test that we can inspect the contents of the tarball


### PR DESCRIPTION
There are all manner of reasons why we want our generated tarballs to be versioned.  The one that is pushing this forward for me is `GlibcBuilder`; we need to build multiple different versions of `glibc` at once, and since I'm a completionist I want to do it "right" and generate all the different versions of `glibc` at once, automatically adding in architectures once we pass the critical threshold of support for each architecture separately.  I didn't want to have different versions on different branches/tags either, so here we are with versioned outputs.  Another reason is that it's useful to know what version of a piece of software you have sitting in that tarball in your downloads folder.  And finally, it's just polite.

Note that this is a breaking change; if you check out this branch, `BinaryBuilder` won't be able to build anything for now.