### PR TITLE
Fix a julia 0.7 deprecation

### DIFF
--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -394,7 +394,7 @@ function parse_7z_list(output::AbstractString)
     end
 
     # Extract within the bounding lines of ------------
-    bounds = [i for i in 1:length(lines) if all([c for c in lines[i]] .== '-')]
+    bounds = [i for i in 1:length(lines) if all([c for c in lines[i]] .== Ref('-'))]
     lines = lines[bounds[1]+1:bounds[2]-1]
 
     # Eliminate `./` prefix, if it exists


### PR DESCRIPTION
This fixes a deprecation warning that I found via StringEncodings.jl that keeps that package from working on 1.0. Would be great if this could be merged, and then quickly a new release tagged.