### PR TITLE
Remove test dependency on `grep`

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -97,7 +97,10 @@ end
     end
 
     # Next, test reading the output of a pipeline()
-    grepline = pipeline(sh(`-c 'printf "Hello\nWorld\nJulia"'`), `grep ul`)
+    grepline = pipeline(
+        sh(`-c 'printf "Hello\nWorld\nJulia\n"'`),
+        sh(`-c 'while read line; do case $line in *ul*) echo $line; esac; done'`)
+    )
     oc = OutputCollector(grepline)
 
     @test wait(oc)


### PR DESCRIPTION
Most windows users don't have `grep.exe` (although Appveyor apparently does) so let's make it slightly easier for them to run the tests with just `busybox`.