### PR TITLE
Remove SHA from REQUIRE since it's a stdlib

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,1 @@
 julia 0.7-rc3
-SHA


### PR DESCRIPTION
This is causing some trouble when trying to use the old package manager.