### PR TITLE
Add CompilerABI versioning into Platforms

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   matrix:
-  - julia_version: 0.7
+  - julia_version: 1.0
   - julia_version: latest
 
 platform:

--- a/src/BinaryProvider.jl
+++ b/src/BinaryProvider.jl
@@ -24,11 +24,6 @@ function __init__()
 
     # Find the right download/compression engines for this platform
     probe_platform_engines!()
-
-    # If we're on a julia that's too old, then fixup the color mappings
-    if !haskey(Base.text_colors, :default)
-        Base.text_colors[:default] = Base.color_normal
-    end
 end
 
 end # module

--- a/src/BinaryProvider.jl
+++ b/src/BinaryProvider.jl
@@ -15,6 +15,9 @@ include("Prefix.jl")
 # Abstraction of "needing" a file, that would trigger an install
 include("Products.jl")
 
+# Compat shims
+include("CompatShims.jl")
+
 function __init__()
     global global_prefix
 

--- a/src/CompatShims.jl
+++ b/src/CompatShims.jl
@@ -1,0 +1,13 @@
+# Compatibility shims for old BP versions, when we make a change
+
+for T in [:Linux, :MacOS, :Windows, :FreeBSD]
+    @eval $T(arch, libc) = $T(arch; libc=libc)
+    @eval $T(arch, libc, call_abi) = $T(arch; libc=libc, call_abi=call_abi)
+end
+
+# Compatibility shim to deal with old build.jl files that don't yet use download_info()
+function platform_key(machine::AbstractString = Sys.MACHINE)
+    Base.depwarn("platform_key() is deprecated, use platform_key_abi() from now on", :binaryprovider_platform_key)
+    platkey = platform_key_abi(machine)
+    return typeof(platkey)(platkey.arch, platkey.libc, platkey.call_abi)
+end

--- a/src/PlatformNames.jl
+++ b/src/PlatformNames.jl
@@ -1,5 +1,5 @@
-export platform_key, platform_dlext, valid_dl_path, arch, wordsize, triplet,
-       Platform, UnknownPlatform, Linux, MacOS, Windows, FreeBSD
+export platform_key, platform_key_abi, platform_dlext, valid_dl_path, arch, wordsize, triplet, choose_download,
+       CompilerABI, Platform, UnknownPlatform, Linux, MacOS, Windows, FreeBSD
 import Base: show
 
 abstract type Platform end
@@ -7,13 +7,51 @@ abstract type Platform end
 struct UnknownPlatform <: Platform
 end
 
+# We need to track our compiler ABI compatibility.
+struct CompilerABI
+    # Major GCC version that we're locked into.
+    # Can be [:gcc4, :gcc7, :gcc8, :gcc_any]
+    gcc_version::Symbol
+
+    # Whether we're using cxx11abi strings
+    # Can be [:cxx03, :cxx11, :cxx_any]
+    cxx_abi::Symbol
+
+    function CompilerABI(gcc_version::Symbol = :gcc_any, cxx_abi::Symbol = :cxx_any)
+        if !in(gcc_version, [:gcc4, :gcc7, :gcc8, :gcc_any])
+            throw(ArgumentError("Unsupported GCC major version '$gcc_version'"))
+        end
+
+        if !in(cxx_abi, [:cxx03, :cxx11, :cxx_any])
+            throw(ArgumentError("Unsupported string ABI '$cxx_abi'"))
+        end
+
+        return new(gcc_version, cxx_abi)
+    end
+end
+
+function show(io::IO, cabi::CompilerABI)
+    write(io, "CompilerABI(")
+    if cabi.gcc_version != :gcc_any || cabi.cxx_abi != :cxx_any
+        write(io, "$(repr(cabi.gcc_version))")
+    end
+    if cabi.cxx_abi != :cxx_any
+        write(io, ", $(repr(cabi.cxx_abi))")
+    end
+    write(io, ")")
+end
+
+
 struct Linux <: Platform
     arch::Symbol
     libc::Symbol
-    abi::Symbol
+    call_abi::Symbol
+    compiler_abi::CompilerABI
 
-    function Linux(arch::Symbol, libc::Symbol=:glibc,
-                                 abi::Symbol=:default_abi)
+    function Linux(arch::Symbol;
+                   libc::Symbol=:glibc,
+                   call_abi::Symbol=:default_abi,
+                   compiler_abi::CompilerABI=CompilerABI())
         if !in(arch, [:i686, :x86_64, :aarch64, :powerpc64le, :armv7l])
             throw(ArgumentError("Unsupported architecture '$arch' for Linux"))
         end
@@ -27,62 +65,70 @@ struct Linux <: Platform
             throw(ArgumentError("Unsupported libc '$libc' for Linux"))
         end
 
-        # The default abi on Linux is blank, so map over to that by default,
+        # The default calling abi on Linux is blank (e.g. not "eabi" or "eabihf"
+        # or anything like that, just "blank"), so map over to that by default
         # except on armv7l, where we map it over to :eabihf
-        if abi === :default_abi
+        if call_abi === :default_abi
             if arch != :armv7l
-                abi = :blank_abi
+                call_abi = :blank_abi
             else
-                abi = :eabihf
+                call_abi = :eabihf
             end
         end
 
-        if !in(abi, [:eabihf, :blank_abi])
-            throw(ArgumentError("Unsupported abi '$abi' for Linux"))
+        if !in(call_abi, [:eabihf, :blank_abi])
+            throw(ArgumentError("Unsupported calling abi '$call_abi' for Linux"))
         end
 
         # If we're constructing for armv7l, we MUST have the eabihf abi
-        if arch == :armv7l && abi != :eabihf
-            throw(ArgumentError("armv7l Linux must use eabihf, not '$abi'"))
+        if arch == :armv7l && call_abi != :eabihf
+            throw(ArgumentError("armv7l Linux must use eabihf, not '$call_abi'"))
         end
         # ...and vice-versa
-        if arch != :armv7l && abi == :eabihf
+        if arch != :armv7l && call_abi == :eabihf
             throw(ArgumentError("eabihf Linux is only on armv7l, not '$arch'!"))
         end
 
-        return new(arch, libc, abi)
+        return new(arch, libc, call_abi, compiler_abi)
     end
 end
 
 struct MacOS <: Platform
     arch::Symbol
     libc::Symbol
-    abi::Symbol
+    call_abi::Symbol
+    compiler_abi::CompilerABI
 
     # Provide defaults for everything because there's really only one MacOS
     # target right now.  Maybe someday iOS.  :fingers_crossed:
-    function MacOS(arch::Symbol=:x86_64, libc::Symbol=:blank_libc,
-                                         abi=:blank_abi)
+    function MacOS(arch::Symbol=:x86_64;
+                   libc::Symbol=:blank_libc,
+                   call_abi::Symbol=:blank_abi,
+                   compiler_abi::CompilerABI=CompilerABI())
         if arch !== :x86_64
             throw(ArgumentError("Unsupported architecture '$arch' for macOS"))
         end
         if libc !== :blank_libc
             throw(ArgumentError("Unsupported libc '$libc' for macOS"))
         end
-        if abi !== :blank_abi
-            throw(ArgumentError("Unsupported abi '$abi' for macOS"))
+        if call_abi !== :blank_abi
+            throw(ArgumentError("Unsupported abi '$call_abi' for macOS"))
         end
-        return new(arch, libc, abi)
+
+        return new(arch, libc, call_abi, compiler_abi)
     end
 end
 
 struct Windows <: Platform
     arch::Symbol
     libc::Symbol
-    abi::Symbol
+    call_abi::Symbol
+    compiler_abi::CompilerABI
 
-    function Windows(arch::Symbol, libc::Symbol=:blank_libc,
-                                   abi::Symbol=:blank_abi)
+    function Windows(arch::Symbol;
+                     libc::Symbol=:blank_libc,
+                     call_abi::Symbol=:blank_abi,
+                     compiler_abi::CompilerABI=CompilerABI())
         if !in(arch, [:i686, :x86_64])
             throw(ArgumentError("Unsupported architecture '$arch' for Windows"))
         end
@@ -91,20 +137,24 @@ struct Windows <: Platform
         if libc !== :blank_libc
             throw(ArgumentError("Unsupported libc '$libc' for Windows"))
         end
-        if abi !== :blank_abi
-            throw(ArgumentError("Unsupported abi '$abi' for Windows"))
+        if call_abi !== :blank_abi
+            throw(ArgumentError("Unsupported abi '$call_abi' for Windows"))
         end
-        return new(arch, libc, abi)
+
+        return new(arch, libc, call_abi, compiler_abi)
     end
 end
 
 struct FreeBSD <: Platform
     arch::Symbol
     libc::Symbol
-    abi::Symbol
+    call_abi::Symbol
+    compiler_abi::CompilerABI
 
-    function FreeBSD(arch::Symbol, libc::Symbol=:blank_libc,
-                                   abi::Symbol=:default_abi)
+    function FreeBSD(arch::Symbol;
+                     libc::Symbol=:blank_libc,
+                     call_abi::Symbol=:default_abi,
+                     compiler_abi::CompilerABI=CompilerABI())
         # `uname` on FreeBSD reports its architecture as amd64 and i386 instead of x86_64
         # and i686, respectively. In the off chance that Julia hasn't done the mapping for
         # us, we'll do it here just in case.
@@ -123,28 +173,28 @@ struct FreeBSD <: Platform
         end
 
         # The default abi on FreeBSD is blank, execpt on armv7l
-        if abi === :default_abi
+        if call_abi === :default_abi
             if arch != :armv7l
-                abi = :blank_abi
+                call_abi = :blank_abi
             else
-                abi = :eabihf
+                call_abi = :eabihf
             end
         end
 
-        if !in(abi, [:eabihf, :blank_abi])
-            throw(ArgumentError("Unsupported abi '$abi' for FreeBSD"))
+        if !in(call_abi, [:eabihf, :blank_abi])
+            throw(ArgumentError("Unsupported calling abi '$call_abi' for FreeBSD"))
         end
 
         # If we're constructing for armv7l, we MUST have the eabihf abi
-        if arch == :armv7l && abi != :eabihf
-            throw(ArgumentError("armv7l FreeBSD must use eabihf, no '$abi'"))
+        if arch == :armv7l && call_abi != :eabihf
+            throw(ArgumentError("armv7l FreeBSD must use eabihf, no '$call_abi'"))
         end
         # ...and vice-versa
-        if arch != :armv7l && abi == :eabihf
+        if arch != :armv7l && call_abi == :eabihf
             throw(ArgumentError("eabihf FreeBSD is only on armv7l, not '$arch'!"))
         end
 
-        return new(arch, libc, abi)
+        return new(arch, libc, call_abi, compiler_abi)
     end
 end
 
@@ -158,7 +208,7 @@ platform_name(p::Linux) = "Linux"
 platform_name(p::MacOS) = "MacOS"
 platform_name(p::Windows) = "Windows"
 platform_name(p::FreeBSD) = "FreeBSD"
-platforn_name(p::UnknownPlatform) = "UnknownPlatform"
+platform_name(p::UnknownPlatform) = "UnknownPlatform"
 
 """
     arch(p::Platform)
@@ -195,21 +245,37 @@ libc(p::Platform) = p.libc
 libc(u::UnknownPlatform) = :unknown
 
 """
-    abi(p::Platform)
+   call_abi(p::Platform)
 
-Get the ABI for the given `Platform` object as a `Symbol`.
+Get the calling ABI for the given `Platform` object as a `Symbol`.
 
 # Examples
 ```jldoctest
-julia> abi(Linux(:x86_64))
+julia> call_abi(Linux(:x86_64))
 :blank_abi
 
-julia> abi(FreeBSD(:armv7l))
+julia> call_abi(FreeBSD(:armv7l))
 :eabihf
 ```
 """
-abi(p::Platform) = p.abi
-abi(u::UnknownPlatform) = :unknown
+call_abi(p::Platform) = p.call_abi
+call_abi(u::UnknownPlatform) = :unknown
+
+"""
+    compiler_abi(p::Platform)
+
+Get the compiler ABI object for the given `Platform`
+# Examples
+```jldoctest
+julia> compiler_abi(Linux(:x86_64))
+CompilerABI(:gcc_any, :cxx_any)
+
+julia> compiler_abi(Linux(:x86_64; compiler_abi=CompilerABI(:gcc7)))
+CompilerABI(:gcc7, :cxx_any)
+```
+"""
+compiler_abi(p::Platform) = p.compiler_abi
+compiler_abi(p::UnknownPlatform) = CompilerABI()
 
 """
     wordsize(platform)
@@ -241,18 +307,27 @@ julia> triplet(MacOS())
 julia> triplet(Windows(:i686))
 "i686-w64-mingw32"
 
-julia> triplet(Linux(:armv7l))
-"arm-linux-gnueabihf"
+julia> triplet(Linux(:armv7l, :default_libc, :default_abi, CompilerABI(:gcc4))
+"arm-linux-gnueabihf-gcc4"
 ```
 """
-triplet(w::Windows) = string(arch_str(w), "-w64-mingw32")
-triplet(m::MacOS) = string(arch_str(m), "-apple-darwin14")
-triplet(l::Linux) = string(arch_str(l), "-linux", libc_str(l), abi_str(l))
-triplet(f::FreeBSD) = string(arch_str(f), "-unknown-freebsd11.1", libc_str(f), abi_str(f))
-triplet(u::UnknownPlatform) = "unknown-unknown-unknown"
+triplet(p::Platform) = string(
+    arch_str(p),
+    vendor_str(p),
+    libc_str(p),
+    call_abi_str(p),
+    compiler_abi_str(p),
+)
+vendor_str(p::Windows) = "-w64-mingw32"
+vendor_str(p::MacOS) = "-apple-darwin14"
+vendor_str(p::Linux) = "-linux"
+vendor_str(p::FreeBSD) = "-unknown-freebsd11.1"
+
+# Special-case UnknownPlatform
+triplet(p::UnknownPlatform) = "unknown-unknown-unknown"
 
 # Helper functions for Linux and FreeBSD libc/abi mishmashes
-arch_str(p::Platform) = (arch(p) == :armv7l) ? "arm" : "$(arch(p))"
+arch_str(p::Platform) = (arch(p) == :armv7l) ? "arm" : string(arch(p))
 function libc_str(p::Platform)
     if libc(p) == :blank_libc
         return ""
@@ -262,20 +337,32 @@ function libc_str(p::Platform)
         return "-$(libc(p))"
     end
 end
-abi_str(p::Platform) = (abi(p) == :blank_abi) ? "" : "$(abi(p))"
+call_abi_str(p::Platform) = (call_abi(p) == :blank_abi) ? "" : string(call_abi(p))
+function compiler_abi_str(cabi::CompilerABI)
+    str = ""
+    if cabi.gcc_version != :gcc_any
+        str *= "-$(cabi.gcc_version)"
+    end
+    if cabi.cxx_abi != :cxx_any
+        str *= "-$(cabi.cxx_abi)"
+    end
+    return str
+end
+compiler_abi_str(p::Platform) = compiler_abi_str(compiler_abi(p))
 
 Sys.isapple(p::Platform) = p isa MacOS
 Sys.islinux(p::Platform) = p isa Linux
 Sys.iswindows(p::Platform) = p isa Windows
 Sys.isbsd(p::Platform) = (p isa FreeBSD) || (p isa MacOS)
 
+
 """
-    platform_key(machine::AbstractString = Sys.MACHINE)
+    platform_key_abi(machine::AbstractString)
 
 Returns the platform key for the current platform, or any other though the
 the use of the `machine` parameter.
 """
-function platform_key(machine::AbstractString = Sys.MACHINE)
+function platform_key_abi(machine::AbstractString)
     # We're going to build a mondo regex here to parse everything:
     arch_mapping = Dict(
         :x86_64 => "(x86_|amd)64",
@@ -285,7 +372,7 @@ function platform_key(machine::AbstractString = Sys.MACHINE)
         :powerpc64le => "p(ower)?pc64le",
     )
     platform_mapping = Dict(
-        :darwin => "-apple-darwin\\d*",
+        :darwin => "-apple-darwin[\\d\\.]*",
         :freebsd => "-(.*-)?freebsd[\\d\\.]*",
         :mingw32 => "-w64-mingw32",
         :linux => "-(.*-)?linux",
@@ -295,9 +382,20 @@ function platform_key(machine::AbstractString = Sys.MACHINE)
         :glibc => "-gnu",
         :musl => "-musl",
     )
-    abi_mapping = Dict(
+    call_abi_mapping = Dict(
         :blank_abi => "",
         :eabihf => "eabihf",
+    )
+    gcc_version_mapping = Dict(
+        :gcc_any => "",
+        :gcc4 => "-gcc4",
+        :gcc7 => "-gcc7",
+        :gcc8 => "-gcc8",
+    )
+    cxx_abi_mapping = Dict(
+        :cxx_any => "",
+        :cxx03 => "-cxx03",
+        :cxx11 => "-cxx11",
     )
 
     # Helper function to collapse dictionary of mappings down into a regex of
@@ -305,10 +403,14 @@ function platform_key(machine::AbstractString = Sys.MACHINE)
     c(mapping) = string("(",join(["(?<$k>$v)" for (k, v) in mapping], "|"), ")")
 
     triplet_regex = Regex(string(
+        "^",
         c(arch_mapping),
         c(platform_mapping),
         c(libc_mapping),
-        c(abi_mapping),
+        c(call_abi_mapping),
+        c(gcc_version_mapping),
+        c(cxx_abi_mapping),
+        "\$",
     ))
 
     m = match(triplet_regex, machine)
@@ -327,22 +429,18 @@ function platform_key(machine::AbstractString = Sys.MACHINE)
         arch = get_field(m, arch_mapping)
         platform = get_field(m, platform_mapping)
         libc = get_field(m, libc_mapping)
-        abi = get_field(m, abi_mapping)
+        call_abi = get_field(m, call_abi_mapping)
+        gcc_version = get_field(m, gcc_version_mapping)
+        cxx_abi = get_field(m, cxx_abi_mapping)
 
         # First, figure out what platform we're dealing with, then sub that off
-        # to the appropriate constructor.  All constructors take in (arch, libc,
-        # abi)  but they will throw errors on trouble, so we catch those and
-        # return the value UnknownPlatform() here to be nicer to client code.
+        # to the appropriate constructor.  If a constructor runs into trouble,
+        # catch the error and return `UnknownPlatform()` here to be nicer to client code.
+        ctors = Dict(:darwin => MacOS, :mingw32 => Windows, :freebsd => FreeBSD, :linux => Linux)
         try
-            if platform == :darwin
-                return MacOS(arch, libc, abi)
-            elseif platform == :mingw32
-                return Windows(arch, libc, abi)
-            elseif platform == :freebsd
-                return FreeBSD(arch, libc, abi)
-            elseif platform == :linux
-                return Linux(arch, libc, abi)
-            end
+            T = ctors[platform]
+            compiler_abi = CompilerABI(gcc_version, cxx_abi)
+            return T(arch, libc=libc, call_abi=call_abi, compiler_abi=compiler_abi)
         catch
         end
     end
@@ -351,19 +449,79 @@ function platform_key(machine::AbstractString = Sys.MACHINE)
     return UnknownPlatform()
 end
 
+
+# Define show() for these Platform objects for two reasons:
+#  - I don't like the `BinaryProvider.` at the beginning of the types;
+#    it's unnecessary as these are exported
+#  - I don't like the :blank_*/:any arguments, they're unnecessary
+function show(io::IO, p::Platform)
+    write(io, "$(platform_name(p))($(repr(arch(p)))")
+
+    if libc(p) != :blank_libc
+        write(io, ", libc=$(repr(libc(p)))")
+    end
+    if call_abi(p) != :blank_abi
+        write(io, ", call_abi=$(repr(call_abi(p)))")
+    end
+    cabi = compiler_abi(p)
+    if cabi.gcc_version != :gcc_any || cabi.cxx_abi != :cxx_any
+        write(io, ", compiler_abi=$(repr(cabi))")
+    end
+    write(io, ")")
+end
+
+
 """
-    platform_dlext(platform::Platform = platform_key())
+    platform_dlext(platform::Platform = platform_key_abi())
 
 Return the dynamic library extension for the given platform, defaulting to the
 currently running platform.  E.g. returns "so" for a Linux-based platform,
 "dll" for a Windows-based platform, etc...
 """
-platform_dlext(l::Linux) = "so"
-platform_dlext(f::FreeBSD) = "so"
-platform_dlext(m::MacOS) = "dylib"
-platform_dlext(w::Windows) = "dll"
-platform_dlext(u::UnknownPlatform) = "unknown"
-platform_dlext() = platform_dlext(platform_key())
+platform_dlext(::Linux) = "so"
+platform_dlext(::FreeBSD) = "so"
+platform_dlext(::MacOS) = "dylib"
+platform_dlext(::Windows) = "dll"
+platform_dlext(::UnknownPlatform) = "unknown"
+platform_dlext() = platform_dlext(platform_key_abi())
+
+"""
+    parse_dl_name_version(path::AbstractString, platform::Platform)
+
+Given a path to a dynamic library, parse out what information we can
+from the filename.  E.g. given something like "lib/libfoo.so.3.2",
+this function returns `"libfoo", v"3.2"`.  If the path name is not a
+valid dynamic library, this method throws an error.  If no soversion
+can be extracted from the filename, as in "libbar.so" this method
+returns `"libbar", nothing`.
+"""
+function parse_dl_name_version(path::AbstractString, platform::Platform)
+    dlext_regexes = Dict(
+        # On Linux, libraries look like `libnettle.so.6.3.0`
+        "so" => r"^(.*?).so((?:\.[\d]+)*)$",
+        # On OSX, libraries look like `libnettle.6.3.dylib`
+        "dylib" => r"^(.*?)((?:\.[\d]+)*).dylib$",
+        # On Windows, libraries look like `libnettle-6.dylib`
+        "dll" => r"^(.*?)(?:-((?:[\.\d]+)*))?.dll$"
+    )
+
+    # Use the regex that matches this platform
+    dlregex = dlext_regexes[platform_dlext(platform)]
+    m = match(dlregex, basename(path))
+    if m === nothing
+        throw(ArgumentError("Invalid dynamic library path '$path'"))
+    end
+
+    # Extract name and version
+    name = m.captures[1]
+    version = m.captures[2]
+    if version === nothing || isempty(version)
+        version = nothing
+    else
+        version = VersionNumber(strip(version, '.'))
+    end
+    return name, version
+end
 
 """
     valid_dl_path(path::AbstractString, platform::Platform)
@@ -373,37 +531,194 @@ E.g. returns `true` for a path like `"usr/lib/libfoo.so.3.5"`, but returns
 `false` for a path like `"libbar.so.f.a"`.
 """
 function valid_dl_path(path::AbstractString, platform::Platform)
-    dlext_regexes = Dict(
-        # On Linux, libraries look like `libnettle.so.6.3.0`
-        "so" => r"^(.*).so(\.[\d]+){0,3}$",
-        # On OSX, libraries look like `libnettle.6.3.dylib`
-        "dylib" => r"^(.*).dylib$",
-        # On Windows, libraries look like `libnettle-6.dylib`
-        "dll" => r"^(.*).dll$"
+    try
+        parse_dl_name_version(path, platform)
+        return true
+    catch
+        return false
+    end
+end
+
+"""
+    detect_libgfortran_abi()
+
+Introspects the currently running Julia process to see what version of
+libgfortran is loaded, and determines the appropriate ABI that should be
+downloaded for this Julia version.
+"""
+function detect_libgfortran_abi()
+    libgfortran_paths = filter(x -> occursin("libgfortran", x), dllist())
+    if isempty(libgfortran_paths)
+         # One day, I hope to not be linking against libgfortran in base Julia
+        return :gcc_any
+    end
+
+    # Extract the version number from this libgfortran.  Ironically, parse_dl_name_version()
+    # wants a Platform, but we may not have initialized the default platform key yet when we
+    # run this method for the first time (since we need the output of this function to set
+    # that default platform) so we manually pass in Sys.MACHINE.  :P
+    name, version = parse_dl_name_version(first(libgfortran_paths), platform_key_abi(Sys.MACHINE))
+    if version === nothing
+        @warn("Unable to determine libgfortran version from '$(first(libgfortran_paths))'; returning :gcc_any")
+        return :gcc_any
+    end
+    libgfortran_to_gcc = Dict(
+        3 => :gcc4,
+        4 => :gcc7,
+        5 => :gcc8,
     )
+    if !in(version.major, keys(libgfortran_to_gcc))
+        @warn("Unsupported libgfortran version '$version'")
+        return :gcc_any
+    end
+    return libgfortran_to_gcc[version.major]
+end
 
-    # Given a platform, find the dlext regex that matches it
-    dlregex = dlext_regexes[platform_dlext(platform)]
+"""
+    detect_libstdcxx_abi()
 
-    # Return whether or not that regex matches the basename of the given path
-    return occursin(dlregex, basename(path))
+Introspects the currently running Julia process to find out what version of libstdc++
+it is linked to (if any), as a proxy for GCC version compatibility.  E.g. if we are
+linked against libstdc++.so.19, binary dependencies built by GCC 8.1.0 will have linker
+errors.  This method returns the maximum GCC abi that we can support.
+"""
+function detect_libstdcxx_abi()
+    libstdcxx_paths = filter(x -> occursin("libstdc++", x), dllist())
+    if isempty(libstdcxx_paths)
+        # This can happen if we were built by clang, so we don't link against
+        # libstdc++ at all.
+        return :gcc_any
+    end
+
+    # Extract all pieces of `.gnu.version_d` from libstdc++.so, find the `GLIBCXX_*`
+    # symbols, and use the maximum version of that to find the GLIBCXX ABI version number
+    #version_symbols = readmeta(first(libstdcxx_paths)) do oh
+    #    unique(vcat((x -> x.names).(ELFVersionData(oh))...))
+    #end
+    #version_symbols = filter(x -> startswith(x, "GLIBCXX_"), version_symbols)
+    #max_version = maximum([VersionNumber(split(v, "_")[2]) for v in version_symbols])
+
+    # ^^ Okay, that's really cool, but unfortunately it introduces a dependency on
+    # ObjectFile which is unacceptable for us.  So instead we just brute-force it.
+    max_version = v"3.4.0"
+    hdl = dlopen(first(libstdcxx_paths))
+    for minor_version in 1:26
+        if dlsym_e(hdl, "GLIBCXX_3.4.$(minor_version)") != C_NULL
+            max_version = VersionNumber("3.4.$(minor_version)")
+        end
+    end
+    dlclose(hdl)
+
+    # Full list available here: https://gcc.gnu.org/onlinedocs/libstdc++/manual/abi.html
+    if max_version < v"3.4.18"
+        error("libstdc++ ABI version '$max_version' too small; please build Julia with GCC >= 4.8.5")
+    elseif max_version < v"3.4.23"
+        # If we aren't up to 7.1.0, then we fall all the way back to 4.8.5
+        return :gcc4
+    elseif max_version < v"3.4.25"
+        return :gcc7
+    else
+        return :gcc8
+    end
+end
+
+"""
+    detect_cxx11_string_abi()
+
+Introspects the currently running Julia process to see what version of the C++11 string
+ABI it was compiled with.  (In reality, it checks for symbols within LLVM, but that is
+close enough for our purposes, as you can't mix linkages between Julia and LLVM if they
+are not compiled in the same way).
+"""
+function detect_cxx11_string_abi()
+    hdl = dlopen(@static Sys.iswindows() ? "LLVM" : "libLLVM")
+    if hdl == C_NULL
+        error("Unable to open libLLVM!")
+    end
+
+    # Check for llvm::sys::getProcessTriple(), first without cxx11 tag:
+    if dlsym_e(hdl, "_ZN4llvm3sys16getProcessTripleEv") != C_NULL
+        return :cxx03
+    elseif dlsym_e(hdl, "_ZN4llvm3sys16getProcessTripleB5cxx11Ev") != C_NULL
+        return :cxx11
+    else
+        error("Unable to find llvm::sys::getProcessTriple() in libLLVM!")
+    end
+end
+
+function detect_compiler_abi()
+    gcc_version = detect_libgfortran_abi()
+    cxx11_string_abi = detect_cxx11_string_abi()
+
+    # If we have no constraint from libgfortran linkage (impossible within current
+    # Julia, but let's be planning for the future here) then inspect libstdc++.
+    if gcc_version == :gcc_any
+        gcc_version = detect_libstdcxx_abi()
+    end
+
+    return CompilerABI(gcc_version, cxx11_string_abi)
 end
 
 
-# Define show() for these objects for two reasons:
-#  - I don't like the `BinaryProvider.` at the beginning of the types;
-#    it's unnecessary as these are exported
-#  - I don't like the :blank_* arguments, they're unnecessary
-function show(io::IO, p::Platform)
-    write(io, "$(platform_name(p))($(repr(arch(p)))")
-    omit_libc = libc(p) == :blank_libc
-    omit_abi = abi(p) == :blank_abi
+# Cache the default platform_key_abi() since that's by far the most common way
+# we call platform_key_abi(), and we don't want to parse the same thing over
+# and over and over again.  Note that we manually slap on a compiler abi
+# string onto the end, so as to encode that in Sys.MACHINE like we expect our
+# triplets to be encoded.
+default_platkey = platform_key_abi(string(
+    Sys.MACHINE,
+    compiler_abi_str(detect_compiler_abi()),
+))
+function platform_key_abi()
+    global default_platkey
+    return default_platkey
+end
 
-    if !omit_libc || !omit_abi
-        write(io, ", $(repr(libc(p)))")
+"""
+    choose_download(download_info::Dict, platform::Platform = platform_key_abi())
+
+Given a `download_info` dictionary mapping platforms to some value, choose
+the value whose key best matches `platform`, throwing an error if no matches
+can be found.
+
+Platform attributes such as architecture, libc, calling ABI, etc... must all
+match exactly, however attributes such as compiler ABI can have wildcards
+within them such as `:gcc_any` which matches any version of GCC.
+"""
+function choose_download(download_info::Dict, platform::Platform = platform_key_abi())
+    # We're going to find all keys of download_info that satisfies the rigidd
+    # constraints first, these are things that are simple equality checks:
+    function rigid_constraints(p)
+        return typeof(p) <: typeof(platform) && (arch(p) == arch(platform)) &&
+               (libc(p) == libc(platform)) && (call_abi(p) == call_abi(platform))
     end
-    if !omit_abi
-        write(io, ", $(repr(abi(p)))")
+    ps = filter(rigid_constraints, keys(download_info))
+
+    # The flexible constraints are ones that can do equals, but also have things
+    # like "any" values, etc....
+    function flexible_constraints(p)
+        p1 = compiler_abi(p)
+        p2 = compiler_abi(platform)
+        gcc_match = (p1.gcc_version == :gcc_any
+                  || p2.gcc_version == :gcc_any
+                  || p1.gcc_version == p2.gcc_version)
+        cxx_match = (p1.cxx_abi == :cxx_any
+                  || p2.cxx_abi == :cxx_any
+                  || p1.cxx_abi == p2.cxx_abi)
+        return gcc_match && cxx_match
     end
-    write(io, ")")
+    ps = collect(filter(flexible_constraints, ps))
+
+    if isempty(ps)
+        throw(ArgumentError("Unable to find matching download for $(platform)"))
+    end
+
+    # At this point, we may have multiple possibilities.  E.g. if, in the future,
+    # Julia can be built without a direct dependency on libgfortran, we may match
+    # multiple tarballs that vary only within their libgfortran ABI.  To narrow it
+    # down, we just sort by triplet, then pick the last one.  This has the effect
+    # of generally choosing the latest release (e.g. a `libgfortran5` tarball
+    # rather than a `libgfortran3` tarball)
+    p = last(sort(ps, by = p -> triplet(p)))
+    return download_info[p]
 end

--- a/src/Prefix.jl
+++ b/src/Prefix.jl
@@ -233,7 +233,7 @@ Given the path to a tarball, return the name, platform key and version of that
 tarball. If any of those things cannot be found, throw an error.
 """
 function extract_name_version_platform_key(path::AbstractString)
-    m = match(r"^(.*?)\.v(.*?)\.([^\.\-]+-.*).tar.gz$", basename(path))
+    m = match(r"^(.*?)\.v(.*?)\.([^\.\-]+-[^\.\-]+-([^\-]+-){0,2}[^\-]+).tar.gz$", basename(path))
     if m === nothing
         error("Could not parse name, platform key and version from $(path)")
     end
@@ -318,7 +318,7 @@ function install(tarball_url::AbstractString,
             platform = extract_platform_key(tarball_url)
 
             # Check if we had a well-formed platform that just doesn't match
-            if platform_key_abi() != platform
+            if !platforms_match(platform, platform_key_abi())
                 msg = replace(strip("""
                 Will not install a tarball of platform $(triplet(platform)) on
                 a system of platform $(triplet(platform_key_abi())) unless

--- a/src/Products.jl
+++ b/src/Products.jl
@@ -162,7 +162,7 @@ function locate(lp::LibraryProduct; verbose::Bool = false,
                 end
 
                 # If it does, try to `dlopen()` it if the current platform is good
-                if platform == platform_key_abi()
+                if platforms_match(platform, platform_key_abi())
                     if isolate
                         # Isolated dlopen is a lot slower, but safer
                         if success(`$(Base.julia_cmd()) -e "import Libdl; Libdl.dlopen(\"$dl_path\")"`)

--- a/src/Products.jl
+++ b/src/Products.jl
@@ -170,7 +170,7 @@ function locate(lp::LibraryProduct; verbose::Bool = false,
                         end
                     else
                         hdl = Libdl.dlopen_e(dl_path)
-                        if hdl != C_NULL
+                        if !(hdl in (C_NULL, nothing))
                             Libdl.dlclose(hdl)
                             return dl_path
                         end
@@ -459,7 +459,7 @@ function write_deps_file(depsjl_path::AbstractString, products::Vector{P};
             # For Library products, check that we can dlopen it:
             if typeof(product) <: LibraryProduct
                 println(depsjl_file, """
-                    if Libdl.dlopen_e($(varname)) == C_NULL
+                    if Libdl.dlopen_e($(varname)) in (C_NULL, nothing)
                         error("\$($(varname)) cannot be opened, $(rebuild)")
                     end
                 """)

--- a/test/LibFoo.jl/Project.toml
+++ b/test/LibFoo.jl/Project.toml
@@ -6,3 +6,4 @@ version = "0.1.0"
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/LibFoo.jl/deps/build.jl
+++ b/test/LibFoo.jl/deps/build.jl
@@ -32,12 +32,16 @@ download_info = Dict(
 )
 # First, check to see if we're all satisfied
 if any(!satisfied(p; verbose=verbose) for p in products)
-    if platform_key() in keys(download_info)
+    try
         # Download and install binaries
-        url, tarball_hash = download_info[platform_key()]
+        url, tarball_hash = choose_download(download_info)
         install(url, tarball_hash; prefix=prefix, force=true, verbose=true)
-    else
-        error("Your platform $(Sys.MACHINE) is not supported by this package!")
+    catch e
+        if typeof(e) <: ArgumentError
+            error("Your platform $(Sys.MACHINE) is not supported by this package!")
+        else
+            rethrow(e)
+        end
     end
 
     # Finally, write out a deps.jl file

--- a/test/LibFoo.jl/src/LibFoo.jl
+++ b/test/LibFoo.jl/src/LibFoo.jl
@@ -1,5 +1,5 @@
 module LibFoo
-using Compat.Libdl
+using Libdl
 
 # Load in `deps.jl`, complaining if it does not exist
 const depsjl_path = joinpath(dirname(@__FILE__), "..", "deps", "deps.jl")

--- a/test/LibFoo.jl/test/runtests.jl
+++ b/test/LibFoo.jl/test/runtests.jl
@@ -1,4 +1,4 @@
-using Compat.Test
+using Test
 using LibFoo
 
 @test call_fooifier(2.2, 1.1) ≈ 2*2.2^2 - 1.1


### PR DESCRIPTION
This adds a new `libgfortran_abi` portion to all platforms.  When parsing and generating triplets, a new tag is added onto the end (if it is not present, it is assumed there is no fortran code present within the tarball, and it therefore has no dependence on a gfortran ABI).

Tarball installation is now not quite as simple as finding the appropriate key within a dictionary; it is now (theoretically) possible that multiple keys within a 
 download_info` dict can apply to the same julia installation.  (E.g. if the julia installation has no gfortran already linked into it, then a libgfortran3 linked tarball and a libgfortran4 linked tarball are both applicable).   To resolve ambiguities, the `choose_download()` function is now available and should be used to pull out the `url` and `hash` from a `download_info` dictionary.

To give a concrete example; this is going to cause the triplets of our tarballs to start looking like: `x86_64-linux-gnu-libgfortran3`, which means the contents of this tarball are linked against `libgfortran.so.3`, whereas just `x86_64-linux-gnu` means there is no dependence on `libgfortran` at all, and thus can be installed on any machine.

This has the nice side-effect of being completely backwards compatible, with the minor exception that all `build.jl` files will need to be updated to use `choose_download()`.  But since I'm hoping to move away from users embedding `build.jl` files into their packages and toward completely auto-generated `.jll` packages, that's a minor concern.