### PR TITLE
Add `withenv()`

### DIFF
--- a/src/BinaryProvider.jl
+++ b/src/BinaryProvider.jl
@@ -23,7 +23,6 @@ function __init__()
 
     # Initialize our global_prefix
     global_prefix = Prefix(joinpath(dirname(@__FILE__), "../", "global_prefix"))
-    activate(global_prefix)
 
     # Find the right download/compression engines for this platform
     probe_platform_engines!()


### PR DESCRIPTION
Remove `activate()` and `deactivate()` since those aren't used by any dependent packages anyway (and I never liked them)