### PR TITLE
Fix issue #121

### DIFF
--- a/src/PlatformNames.jl
+++ b/src/PlatformNames.jl
@@ -611,8 +611,8 @@ function detect_libstdcxx_abi()
     max_version = v"3.4.0"
     hdl = dlopen(first(libstdcxx_paths))
     for minor_version in 1:26
-        if dlsym_e(hdl, "GLIBCXX_3.4.$(minor_version)") != C_NULL
-            max_version = VersionNumber("3.4.$(minor_version)")
+        if dlsym_e(hdl, "GLIBCXX_3.4.$(minor_version)") == C_NULL
+            max_version = VersionNumber("3.4.$(minor_version - 1)")
         end
     end
     dlclose(hdl)


### PR DESCRIPTION
The original method finds the minimum not the maximum version, because if there are both `GLIBCXX_3.4.1` and `GLIBCXX_3.4.24`, then max_version will equal to the first one.