### PR TITLE
add changes to allow building on cygwin builds

### DIFF
--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -226,11 +226,11 @@ function probe_platform_engines!(;verbose::Bool = false)
             elseif endswith(tarball_path, ".bz2")
                 Jjz = "j"
             end
-            return `$tar_cmd -x$(Jjz)f $(tarball_path) --directory=$(out_path)`
+            return `$tar_cmd -x$(Jjz)f $(tarball_path) --directory=$(escape_string(out_path)) --force-local`
         end
         package_tar = (in_path, tarball_path) ->
-            `$tar_cmd -czvf $tarball_path -C $(in_path) .`
-        list_tar = (in_path) -> `$tar_cmd -tzf $in_path`
+            `$tar_cmd -czvf $tarball_path -C $(in_path) . --force-local`
+        list_tar = (in_path) -> `$tar_cmd -tzf $in_path --force-local`
         push!(compression_engines, (
             `$tar_cmd --help`,
             unpack_tar,


### PR DESCRIPTION
I have a build on cygwin on Windows and encountered some problems. This seems to resolve it (can build SpecialFunctions.jl now).

Without the `escape_string`  I got:

```
tar: C\:\\Users\\Kristoffer\\.julia\\packages\\SpecialFunctions\fvheQ\\deps\\usr: Cannot open: No such file or directory
tar: Error is not recoverable: exiting now
```

Without the `--force-local` I got

```
tar (child): Cannot connect to C: resolve failed
```

See https://stackoverflow.com/a/37996249.