### PR TITLE
Example bug: Catch MethodError for when `choose_download(download_info)` returns `nothing`

### DIFF
--- a/test/LibFoo.jl/deps/build.jl
+++ b/test/LibFoo.jl/deps/build.jl
@@ -37,7 +37,7 @@ if any(!satisfied(p; verbose=verbose) for p in products)
         url, tarball_hash = choose_download(download_info)
         install(url, tarball_hash; prefix=prefix, force=true, verbose=true)
     catch e
-        if typeof(e) <: ArgumentError
+        if typeof(e) <: ArgumentError || typeof(e) <: MethodError
             error("Your platform $(Sys.MACHINE) is not supported by this package!")
         else
             rethrow(e)


### PR DESCRIPTION
When a suitable download isn't found, returning `nothing` into the two output targets returns a MethodError because `nothing` can't be iterated, therefore wasn't being caught.
Perhaps `ArgumentError` should've been replaced, but I wasn't sure