### PR TITLE
Fallback to __FILE__ when initializing global_prefix

### DIFF
--- a/src/BinaryProvider.jl
+++ b/src/BinaryProvider.jl
@@ -22,7 +22,10 @@ function __init__()
     global global_prefix
 
     # Initialize our global_prefix
-    global_prefix = Prefix(joinpath(dirname(pathof(@__MODULE__)), "..", "global_prefix"))
+    global_prefix = Prefix(joinpath(dirname(something(
+        pathof(@__MODULE__),  # may be `nothing`; see JuliaLang/julia#31662
+        @__FILE__,
+    )), "..", "global_prefix"))
 
     # Find the right download/compression engines for this platform
     probe_platform_engines!()


### PR DESCRIPTION
`pathof(@__MODULE__)` cannot be used to find the module path reliably due to JuliaLang/julia#31662.  I suggest to fallback to `@__FILE__`.

Alternatively, a much simpler solution would be to use `@__DIR__`

    global_prefix = Prefix(joinpath(@__DIR__, "..", "global_prefix"))

but this would decrease relocatability #126.
