### PR TITLE
Extended workaround for handling symlinks in tar files

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,16 +1,17 @@
 freebsd_instance:
   image: freebsd-12-0-release-amd64
-freebsd_test_task:
+task:
+  name: FreeBSD
   env:
-    JULIA_VERSION: "1.0"
+    matrix:
+      - JULIA_VERSION: 1.0
+      - JULIA_VERSION: 1.1
+      - JULIA_VERSION: nightly
   install_script:
-    - pkg install -y curl
-    - mkdir -p ~/julia
-    - curl -s -L --retry 7 "https://julialang-s3.julialang.org/bin/freebsd/x64/${JULIA_VERSION}/julia-${JULIA_VERSION}-latest-freebsd-x86_64.tar.gz" | tar -C ~/julia -x -z --strip-components=1 -f -
-    - ln -s "${HOME}/julia/bin/julia" /usr/local/bin/julia
-    - julia --color=yes -e "using InteractiveUtils; versioninfo()"
+    - sh -c "$(fetch https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin/install.sh -o -)"
   build_script:
-    - julia --color=yes -e "using Pkg; Pkg.add(PackageSpec(name=\"BinaryProvider\", path=pwd()))"
-    - julia --color=yes -e "using Pkg; Pkg.build(\"BinaryProvider\")"
+    - cirrusjl build
   test_script:
-    - julia --color=yes -e "using Pkg; Pkg.test(\"BinaryProvider\")"
+    - cirrusjl test
+  coverage_script:
+    - cirrusjl coverage codecov coveralls

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -230,7 +230,7 @@ function probe_platform_engines!(;verbose::Bool = false)
         end
         package_tar = (in_path, tarball_path) ->
             `$tar_cmd -czvf $tarball_path -C $(in_path) .`
-        list_tar = (in_path; verbose = false) -> `$tar_cmd -tzf$(verbose ? ["v"] : []) $in_path`
+        list_tar = (in_path; verbose = false) -> `$tar_cmd -tz$(verbose ? ["v"] : [])f $in_path`
         push!(compression_engines, (
             `$tar_cmd --help`,
             unpack_tar,

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -230,7 +230,7 @@ function probe_platform_engines!(;verbose::Bool = false)
         end
         package_tar = (in_path, tarball_path) ->
             `$tar_cmd -czvf $tarball_path -C $(in_path) .`
-        list_tar = (in_path; verbose = false) -> `$tar_cmd -tz$(verbose ? ["v"] : [])f $in_path`
+        list_tar = (in_path; verbose = false) -> `$tar_cmd $(verbose ? ["-tzvf"] : ["-tzf"]) $in_path`
         push!(compression_engines, (
             `$tar_cmd --help`,
             unpack_tar,

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -230,7 +230,7 @@ function probe_platform_engines!(;verbose::Bool = false)
         end
         package_tar = (in_path, tarball_path) ->
             `$tar_cmd -czvf $tarball_path -C $(in_path) .`
-        list_tar = (in_path; verbose = false) -> `$tar_cmd $(verbose ? ["-tzvf"] : ["-tzf"]) $in_path`
+        list_tar = (in_path; verbose = false) -> `$tar_cmd $(verbose ? "-tzvf" : "-tzf") $in_path`
         push!(compression_engines, (
             `$tar_cmd --help`,
             unpack_tar,

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -361,11 +361,11 @@ function probe_platform_engines!(;verbose::Bool = false)
         ])
 
         # We greatly prefer `7z` as a compression engine on Windows
-        #prepend!(compression_engines, [(`7z --help`, gen_7z("7z")...)])
+        prepend!(compression_engines, [(`7z --help`, gen_7z("7z")...)])
 
         # On windows, we bundle 7z with Julia, so try invoking that directly
         exe7z = joinpath(Sys.BINDIR, "7z.exe")
-        #prepend!(compression_engines, [(`$exe7z --help`, gen_7z(exe7z)...)])
+        prepend!(compression_engines, [(`$exe7z --help`, gen_7z(exe7z)...)])
 
         # And finally, we want to look for sh as busybox as well:
         busybox = joinpath(Sys.BINDIR, "busybox.exe")
@@ -546,24 +546,23 @@ Given the output of `tar -t`, parse out the listed filenames.  This funciton
 used by `list_tarball_files`.
 """
 function parse_tar_list(output::AbstractString)
-    # lines = [chomp(l) for l in split(output, "\n")]
-    # for idx in 1:length(lines)
-    #     if endswith(lines[idx], '\r')
-    #         lines[idx] = lines[idx][1:end-1]
-    #     end
-    # end
-    #
-    # # Drop empty lines and and directories
-    # lines = [l for l in lines if !isempty(l) && !endswith(l, '/')]
-    #
-    # # Eliminate `./` prefix, if it exists
-    # for idx in 1:length(lines)
-    #     if startswith(lines[idx], "./") || startswith(lines[idx], ".\\")
-    #         lines[idx] = lines[idx][3:end]
-    #     end
-    # end
-    lines = [m.captures[1] for m in eachmatch(r"^(.+?)(?<!/\r|/)\r?$"m, output)]
-    @info(output)
+    lines = [chomp(l) for l in split(output, "\n")]
+    for idx in 1:length(lines)
+        if endswith(lines[idx], '\r')
+            lines[idx] = lines[idx][1:end-1]
+        end
+    end
+
+    # Drop empty lines and and directories
+    lines = [l for l in lines if !isempty(l) && !endswith(l, '/')]
+
+    # Eliminate `./` prefix, if it exists
+    for idx in 1:length(lines)
+        if startswith(lines[idx], "./") || startswith(lines[idx], ".\\")
+            lines[idx] = lines[idx][3:end]
+        end
+    end
+
     return lines
 end
 

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -196,8 +196,6 @@ function probe_platform_engines!(;verbose::Bool = false)
         return (tarball_path, out_path, excludelist = "") ->
             pipeline(`$exe7z x $(tarball_path) -y -so`,
                      `$exe7z x -si -y -ttar -o$(out_path)  $(excludelist=="" ? [] : ["-x@" * excludelist])`)
-#            pipeline(`C:\\Users\\m136270\\Desktop\\Misc\\hh\\hh.bat $(tarball_path) $(out_path)`)
-
     end
     package_7z = (exe7z) -> begin
         return (in_path, tarball_path) ->

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -219,15 +219,16 @@ function probe_platform_engines!(;verbose::Bool = false)
 
     write("demoTar.txt","Demo file for tar listing")
     for tar_cmd in [`tar`, `busybox tar`]
-        # determine tar list format
+        # try to determine the tar list format
+        local symlink_parser
         try
             tarListing = read(pipeline(`$tar_cmd -c demoTar.txt`,`$tar_cmd -tv`), String)
             m = match(r"((?:\S+\s+)+?)demoTar\.txt", tarListing)[1]
             nargs = length(split(m, " "; keepempty = false))
             symlink_parser = Regex("^l(?:\\S+\\s+){$nargs}(.+?)(?: -> (.+?))?\\r?\$", "m")
         catch
-            # determination of tar lisst format not successful, using generic expression
-            # this will fail, if the symlink contains space characters (which is highly improbable)
+            # generic expression for symlink parsing
+            # this will fail, if the symlink contains space characters (which is highly improbable, though)
             symlink_parser = r"^l.+? (\S+?)(?: -> (.+?))?\r?$"m
         end
         # Some tar's aren't smart enough to auto-guess decompression method. :(
@@ -293,7 +294,7 @@ function probe_platform_engines!(;verbose::Bool = false)
         # On windows, we bundle 7z with Julia, so try invoking that directly
         exe7z = joinpath(Sys.BINDIR, "7z.exe")
         prepend!(compression_engines, [(`$exe7z --help`, gen_7z(exe7z)...)])
-        
+
         # And finally, we want to look for sh as busybox as well:
         busybox = joinpath(Sys.BINDIR, "busybox.exe")
         prepend!(sh_engines, [(`$busybox sh`)])

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -19,7 +19,7 @@ gen_download_cmd = (url::AbstractString, out_path::AbstractString) ->
     error("Call `probe_platform_engines()` before `gen_download_cmd()`")
 
 """
-    gen_unpack_cmd(tarball_path::AbstractString, out_path::AbstractString; excludelist::AbstractString = nothing)
+    gen_unpack_cmd(tarball_path::AbstractString, out_path::AbstractString; excludelist::Union{AbstractString, Nothing} = nothing)
 
 Return a `Cmd` that will unpack the given `tarball_path` into the given
 `out_path`.  If `out_path` is not already a directory, it will be created.
@@ -29,7 +29,7 @@ This option is mainyl used to exclude symlinks from extraction (see: `copyderef`
 This method is initialized by `probe_platform_engines()`, which should be
 automatically called upon first import of `BinaryProvider`.
 """
-gen_unpack_cmd = (tarball_path::AbstractString, out_path::AbstractString; excludelist::AbstractString = nothing) ->
+gen_unpack_cmd = (tarball_path::AbstractString, out_path::AbstractString; excludelist::Union{AbstractString, Nothing} = nothing) ->
     error("Call `probe_platform_engines()` before `gen_unpack_cmd()`")
 
 """

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -714,7 +714,7 @@ function unpack(tarball_path::AbstractString, dest::AbstractString;
                         end
                     end
                 end
-        end
+            end
         end
         cptry_harder(dest, true_dest)
         rm(dest; recursive=true, force=true)

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -214,8 +214,7 @@ function probe_platform_engines!(;verbose::Bool = false)
     # package_opts_functor, list_opts_functor, parse_functor).  The probulator
     # will check each of them by attempting to run `$test_cmd`, and if that
     # works, will set the global compression functions appropriately.
-    symlink_parser = r"Path = ([^\r\n]+)\r?\n(?:[^\r\n]+\r?\n)+Symbolic Link = ([^\r\n]+)"s
-    gen_7z = (unpack_7z, package_7z, list_7z, parse_7z_list, symlink_parser)
+    gen_7z = (p) -> (unpack_7z(p), package_7z(p), list_7z(p), parse_7z_list, r"Path = ([^\r\n]+)\r?\n(?:[^\r\n]+\r?\n)+Symbolic Link = ([^\r\n]+)"s)
     compression_engines = Tuple[]
 
     write("demoTar.txt","Demo file for tar listing")
@@ -289,11 +288,12 @@ function probe_platform_engines!(;verbose::Bool = false)
         ])
 
         # We greatly prefer `7z` as a compression engine on Windows
-        prepend!(compression_engines, [(`7z --help`, [f("7z") for f in gen_7z[1:3]]..., gen_7z[4:end]...)])
+        prepend!(compression_engines, [(`7z --help`, gen_7z("7z")...)])
 
         # On windows, we bundle 7z with Julia, so try invoking that directly
         exe7z = joinpath(Sys.BINDIR, "7z.exe")
-        prepend!(compression_engines, [(`$exe7z --help`, [f(exe7z) for f in gen_7z[1:3]]..., gen_7z[4:end]...)])
+        prepend!(compression_engines, [(`$exe7z --help`, gen_7z(exe7z)...)])
+        
         # And finally, we want to look for sh as busybox as well:
         busybox = joinpath(Sys.BINDIR, "busybox.exe")
         prepend!(sh_engines, [(`$busybox sh`)])

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -213,6 +213,49 @@ function probe_platform_engines!(;verbose::Bool = false)
     # (?:[^\r\n]+\r?\n)+ = a group of non-empty lines (information belonging to one file is written as a block of lines followed by an empty line)
     # more info on regex and a powerful online tester can be found at https://regex101.com
     # Symbolic Link = ([^\r\n]+)"s) matches the source filename
+    # Demo 7z listing of tar files:
+    # 7-Zip [64] 16.04 : Copyright (c) 1999-2016 Igor Pavlov : 2016-10-04
+    #
+    #
+    # Listing archive:
+    # --
+    # Path =
+    # Type = tar
+    # Code Page = UTF-8
+    #
+    # ----------
+    # Path = .
+    # Folder = +
+    # Size = 0
+    # Packed Size = 0
+    # Modified = 2018-08-22 11:44:23
+    # Mode = 0rwxrwxr-x
+    # User = travis
+    # Group = travis
+    # Symbolic Link =
+    # Hard Link =
+
+    # Path = .\lib\libpng.a
+    # Folder = -
+    # Size = 10
+    # Packed Size = 0
+    # Modified = 2018-08-22 11:44:51
+    # Mode = 0rwxrwxrwx
+    # User = travis
+    # Group = travis
+    # Symbolic Link = libpng16.a
+    # Hard Link =
+    #
+    # Path = .\lib\libpng16.a
+    # Folder = -
+    # Size = 334498
+    # Packed Size = 334848
+    # Modified = 2018-08-22 11:44:49
+    # Mode = 0rw-r--r--
+    # User = travis
+    # Group = travis
+    # Symbolic Link =
+    # Hard Link =
     gen_7z = (p) -> (unpack_7z(p), package_7z(p), list_7z(p), parse_7z_list, r"Path = ([^\r\n]+)\r?\n(?:[^\r\n]+\r?\n)+Symbolic Link = ([^\r\n]+)"s)
     compression_engines = Tuple[]
 
@@ -267,7 +310,7 @@ function probe_platform_engines!(;verbose::Bool = false)
             elseif endswith(tarball_path, ".bz2")
                 Jjz = "j"
             end
-            excludeoption = excludelist=="" ? `` : `--exclude-from='$excludelist'`
+            excludeoption = excludelist=="" ? `` : `--exclude-from="$excludelist"`
             return `$tar_cmd -x$(Jjz)f $(tarball_path) --directory=$(out_path) $(excludeoption)`
         end
         package_tar = (in_path, tarball_path) ->

--- a/src/Prefix.jl
+++ b/src/Prefix.jl
@@ -485,7 +485,7 @@ function list_tarball_symlinks(tarball_path::AbstractString; verbose::Bool = fal
         error("Could not list contents of tarball $(tarball_path)")
     end
     output = collect_stdout(oc)
-
+    @debug(output)
     if match(r"^[\r\n]*7-Zip"s, output) != nothing
         mm = eachmatch(r"Path = ([^\r\n]+)\r?\n(?:[^\r\n]+\r?\n)+Symbolic Link = ([^\r\n]+)"s, output)
     else

--- a/src/Prefix.jl
+++ b/src/Prefix.jl
@@ -489,7 +489,7 @@ function list_tarball_symlinks(tarball_path::AbstractString; verbose::Bool = fal
     if match(r"^[\r\n]*7-Zip"s, output) != nothing
         mm = eachmatch(r"Path = ([^\r\n]+)\r?\n(?:[^\r\n]+\r?\n)+Symbolic Link = ([^\r\n]+)"s, output)
     else
-        mm = eachmatch(r"^l\S+ \S+\s+\d+ \S+ \S+ (.+?)(?: -> (.+?))?\r?$"m, output)
+        mm = eachmatch(r"^l\S+ \S+\s+\d+\s+\S+\s+\S+(?:\s+[\d:]+ \d+)? (?:\.[\\/])?(.+?)(?: -> (.+?))?\r?$"m, output)
     end
     return [m.captures[1] => joinpath(splitdir(m.captures[1])[1], split(m.captures[2], "/")...) for m in mm]
 end

--- a/src/Prefix.jl
+++ b/src/Prefix.jl
@@ -476,6 +476,9 @@ end
 Given a `.tar.gz` filepath, return a dictionary of symlinks in the archive
 """
 function list_tarball_symlinks(tarball_path::AbstractString; verbose::Bool = false)
+    if !isdefined(BinaryProvider, :gen_symlink_parser)
+        error("Call `probe_platform_engines!()` before `list_tarball_symlinks()`")
+    end
     oc = OutputCollector(gen_list_tarball_cmd(tarball_path; verbose = true); verbose = verbose)
     try
         if !wait(oc)

--- a/src/Prefix.jl
+++ b/src/Prefix.jl
@@ -485,7 +485,7 @@ function list_tarball_symlinks(tarball_path::AbstractString; verbose::Bool = fal
         error("Could not list contents of tarball $(tarball_path)")
     end
     output = collect_stdout(oc)
-    @debug(output)
+    @info("copyderef2: \r\n" * output)
     if match(r"^[\r\n]*7-Zip"s, output) != nothing
         mm = eachmatch(r"Path = ([^\r\n]+)\r?\n(?:[^\r\n]+\r?\n)+Symbolic Link = ([^\r\n]+)"s, output)
     else

--- a/src/Prefix.jl
+++ b/src/Prefix.jl
@@ -485,7 +485,6 @@ function list_tarball_symlinks(tarball_path::AbstractString; verbose::Bool = fal
         error("Could not list contents of tarball $(tarball_path)")
     end
     output = collect_stdout(oc)
-    # @info("copyderef2: \r\n" * output)
 
     mm = [m.captures for m in eachmatch(gen_symlink_parser, output)]
     symlinks = [m[1] => joinpath(splitdir(m[1])[1], split(m[2], "/")...) for m in mm]

--- a/src/Prefix.jl
+++ b/src/Prefix.jl
@@ -486,21 +486,9 @@ function list_tarball_symlinks(tarball_path::AbstractString; verbose::Bool = fal
     end
     output = collect_stdout(oc)
     # @info("copyderef2: \r\n" * output)
-    if match(r"^[\r\n]*7-Zip"s, output) != nothing
-        mm = eachmatch(r"Path = ([^\r\n]+)\r?\n(?:[^\r\n]+\r?\n)+Symbolic Link = ([^\r\n]+)"s, output)
-        symlinks = [m.captures[1] => joinpath(splitdir(m.captures[1])[1], split(m.captures[2], "/")...) for m in mm]
-    else
-        #determine number of lines with symlinks
-        numberOfLinks = length([m for m in eachmatch(r"^l"m, output)])
-        # first regex
-        mm = eachmatch(r"^l([^:]+(?::\d\d)+|.+  \d{4}) (.+?)(?: -> (.+?))?\r?$"m, output)
-        symlinks = [m.captures[2] => joinpath(splitdir(m.captures[2])[1], split(m.captures[3], "/")...) for m in mm]
-        #if not successful try another one
-        if length(symlinks) != numberOfLinks
-            mm = eachmatch(r"^l.+ \d{4} (.+?)(?: -> (.+?))?\r?$"m, output)
-            symlinks = [m.captures[1] => joinpath(splitdir(m.captures[1])[1], split(m.captures[2], "/")...) for m in mm]
-        end
-    end
+
+    mm = [m.captures for m in eachmatch(gen_symlink_parser, output)]
+    symlinks = [m[1] => joinpath(splitdir(m[1])[1], split(m[2], "/")...) for m in mm]
     return symlinks
 end
 

--- a/src/Prefix.jl
+++ b/src/Prefix.jl
@@ -7,7 +7,7 @@ using SHA
 export Prefix, bindir, libdir, includedir, logdir, activate, deactivate,
        extract_name_version_platform_key, extract_platform_key, isinstalled,
        install, uninstall, manifest_from_url, manifest_for_file,
-       list_tarball_files, verify, temp_prefix, package
+       list_tarball_files, list_tarball_symlinks, verify, temp_prefix, package
 
 
 # Temporary hack around https://github.com/JuliaLang/julia/issues/26685

--- a/src/Prefix.jl
+++ b/src/Prefix.jl
@@ -485,11 +485,11 @@ function list_tarball_symlinks(tarball_path::AbstractString; verbose::Bool = fal
         error("Could not list contents of tarball $(tarball_path)")
     end
     output = collect_stdout(oc)
-    @info("copyderef2: \r\n" * output)
+    # @info("copyderef2: \r\n" * output)
     if match(r"^[\r\n]*7-Zip"s, output) != nothing
         mm = eachmatch(r"Path = ([^\r\n]+)\r?\n(?:[^\r\n]+\r?\n)+Symbolic Link = ([^\r\n]+)"s, output)
     else
-        mm = eachmatch(r"^l\S+ \S+\s+\d+\s+\S+\s+\S+(?:\s+[\d:]+ \d+)? (?:\.[\\/])?(.+?)(?: -> (.+?))?\r?$"m, output)
+        mm = eachmatch(r"^l\S+\s+(?:\S+|\S+ \S+\s+\S+)\s+\d+ (?:\S+ \S+|\S+\s+\d+\s+\d+) (?:\.[\\/])?(.+?)(?: -> (.+?))?\r?$"m, output)
     end
     return [m.captures[1] => joinpath(splitdir(m.captures[1])[1], split(m.captures[2], "/")...) for m in mm]
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -774,7 +774,7 @@ end
 const collapse_url = "https://github.com/staticfloat/small_bin/raw/master/collapse_the_symlink/collapse_the_symlink.tar.gz"
 const collapse_hash = "956c1201405f64d3465cc28cb0dec9d63c11a08cad28c381e13bb22e1fc469d3"
 @testset "Copyderef unpacking" begin
-    withenv("BINARYPROVIDER_COPYDEREF2" => "true") do
+    withenv("BINARYPROVIDER_COPYDEREF" => "true") do
         temp_prefix() do prefix
             target_dir = joinpath(prefix.path, "target")
             download_verify_unpack(collapse_url, collapse_hash, target_dir; verbose=true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -374,7 +374,7 @@ end
                 @test success(sh(`prefix_path_test.sh`))
             end
         end
-        
+
         # Test that we can control libdir() via platform arguments
         @test libdir(prefix, Linux(:x86_64)) == joinpath(prefix, "lib")
         @test libdir(prefix, Windows(:x86_64)) == joinpath(prefix, "bin")
@@ -478,7 +478,7 @@ end
             touch(l_path)
             @test satisfied(l, verbose=true, platform=p)
             @test satisfied(l, verbose=true, platform=p, isolate=true)
-            
+
             # Check LibraryProduct objects with explicit directory paths
             ld = LibraryProduct(libdir(prefix, p), "libfoo", :libfoo)
             @test satisfied(ld, verbose=true, platform=p)
@@ -774,7 +774,7 @@ end
 const collapse_url = "https://github.com/staticfloat/small_bin/raw/master/collapse_the_symlink/collapse_the_symlink.tar.gz"
 const collapse_hash = "956c1201405f64d3465cc28cb0dec9d63c11a08cad28c381e13bb22e1fc469d3"
 @testset "Copyderef unpacking" begin
-    withenv("BINARYPROVIDER_COPYDEREF" => "true") do
+    withenv("BINARYPROVIDER_COPYDEREF2" => "true") do
         temp_prefix() do prefix
             target_dir = joinpath(prefix.path, "target")
             download_verify_unpack(collapse_url, collapse_hash, target_dir; verbose=true)
@@ -818,20 +818,20 @@ end
 
     @test choose_download(platforms, Linux(:x86_64)) == "linux8"
     @test choose_download(platforms, Linux(:x86_64, compiler_abi=CompilerABI(:gcc7))) == "linux7"
-    
+
     # Ambiguity test
     @test choose_download(platforms, Linux(:aarch64)) == "linux5"
     @test choose_download(platforms, Linux(:aarch64; compiler_abi=CompilerABI(:gcc4))) == "linux5"
     @test choose_download(platforms, Linux(:aarch64; compiler_abi=CompilerABI(:gcc5))) == "linux5"
     @test choose_download(platforms, Linux(:aarch64; compiler_abi=CompilerABI(:gcc6))) == "linux5"
     @test choose_download(platforms, Linux(:aarch64; compiler_abi=CompilerABI(:gcc7))) == nothing
-    
+
     @test choose_download(platforms, MacOS(:x86_64)) == "mac4"
     @test choose_download(platforms, MacOS(:x86_64, compiler_abi=CompilerABI(:gcc7))) == nothing
 
     @test choose_download(platforms, Windows(:x86_64, compiler_abi=CompilerABI(:gcc_any, :cxx11))) == "win"
     @test choose_download(platforms, Windows(:x86_64, compiler_abi=CompilerABI(:gcc_any, :cxx03))) == nothing
-   
+
     # Poor little guy
     @test choose_download(platforms, FreeBSD(:x86_64)) == nothing
 end


### PR DESCRIPTION
I propose another workaround additional to `copyderef`.

`copyderef2` is automatically detected in case that neither `tempdir` nor `dest` supports symlinks.
In that case the symlinks of the tarfile are returned by the new function `list_tarball_symlinks`.
For this purpose the generic `list` functions have been modified to support a keyword argument `verbose`.
Regular expressions are used to parse the output and return a dictionary of symlinks.
The symlinks are exluded during extraction and the original source files of the symlinks are copied after extraction.