### PR TITLE
tar commands and windows paths

### DIFF
--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -317,11 +317,26 @@ function probe_platform_engines!(;verbose::Bool = false)
             elseif endswith(tarball_path, ".bz2")
                 Jjz = "j"
             end
-            return `$tar_cmd -x$(Jjz)f $(tarball_path) --directory=$(out_path) $(excludelist == nothing ? [] : "--exclude-from=$(excludelist)")`
+            return `$tar_cmd -x$(Jjz)f $(tarball_path) -C$(out_path) $(excludelist == nothing ? [] : "-X$(excludelist)")`
         end
-        package_tar = (in_path, tarball_path) ->
-            `$tar_cmd -czvf $tarball_path -C $(in_path) .`
-        list_tar = (in_path; verbose = false) -> `$tar_cmd $(verbose ? "-tzvf" : "-tzf") $in_path`
+        package_tar = (in_path, tarball_path) -> begin
+            Jjz = "z"
+            if endswith(tarball_path, ".xz")
+                Jjz = "J"
+            elseif endswith(tarball_path, ".bz2")
+                Jjz = "j"
+            end
+            return `$tar_cmd -c$(Jjz)vf $tarball_path -C$(in_path) .`
+        end
+        list_tar = (in_path; verbose = false) -> begin
+            Jjz = "z"
+            if endswith(in_path, ".xz")
+                Jjz = "J"
+            elseif endswith(in_path, ".bz2")
+                Jjz = "j"
+            end
+            return `$tar_cmd $(verbose ? "-t$(Jjz)vf" : "-t$(Jjz)f") $in_path`
+        end
         push!(compression_engines, (
             `$tar_cmd --help`,
             unpack_tar,
@@ -367,11 +382,11 @@ function probe_platform_engines!(;verbose::Bool = false)
         ])
 
         # We greatly prefer `7z` as a compression engine on Windows
-        prepend!(compression_engines, [(`7z --help`, gen_7z("7z")...)])
+        #prepend!(compression_engines, [(`7z --help`, gen_7z("7z")...)])
 
         # On windows, we bundle 7z with Julia, so try invoking that directly
         exe7z = joinpath(Sys.BINDIR, "7z.exe")
-        prepend!(compression_engines, [(`$exe7z --help`, gen_7z(exe7z)...)])
+        #prepend!(compression_engines, [(`$exe7z --help`, gen_7z(exe7z)...)])
 
         # And finally, we want to look for sh as busybox as well:
         busybox = joinpath(Sys.BINDIR, "busybox.exe")
@@ -569,7 +584,8 @@ function parse_tar_list(output::AbstractString)
         end
     end
 
-    return lines
+    # make sure paths are always returned in the system's default way
+    return Sys.iswindows() ? replace.(lines, ['/' => '\\']) : lines
 end
 
 """
@@ -752,7 +768,7 @@ function unpack(tarball_path::AbstractString, dest::AbstractString;
             close(io)
         end
     end
-
+    
     oc = OutputCollector(gen_unpack_cmd(tarball_path, dest, excludelist); verbose=verbose)
     try
         if !wait(oc)
@@ -768,8 +784,8 @@ function unpack(tarball_path::AbstractString, dest::AbstractString;
     if copyderef && length(symlinks) > 0
         @info("Replacing symlinks in tarball by their source files ...\n" * join(string.(symlinks),"\n"))
         for s in symlinks
-            sourcefile = joinpath(dest, replace(s[2], r"(?:\.[\\/])(.*)" => s"\1"))
-            destfile = joinpath(dest, replace(s[1], r"(?:\.[\\/])(.*)" => s"\1"))
+            sourcefile = normpath(joinpath(dest, s[2]))
+            destfile   = normpath(joinpath(dest, s[1]))
 
             if isfile(sourcefile)
                 cp(sourcefile, destfile, force = true)

--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -382,11 +382,11 @@ function probe_platform_engines!(;verbose::Bool = false)
         ])
 
         # We greatly prefer `7z` as a compression engine on Windows
-        #prepend!(compression_engines, [(`7z --help`, gen_7z("7z")...)])
+        prepend!(compression_engines, [(`7z --help`, gen_7z("7z")...)])
 
         # On windows, we bundle 7z with Julia, so try invoking that directly
         exe7z = joinpath(Sys.BINDIR, "7z.exe")
-        #prepend!(compression_engines, [(`$exe7z --help`, gen_7z(exe7z)...)])
+        prepend!(compression_engines, [(`$exe7z --help`, gen_7z(exe7z)...)])
 
         # And finally, we want to look for sh as busybox as well:
         busybox = joinpath(Sys.BINDIR, "busybox.exe")

--- a/src/Prefix.jl
+++ b/src/Prefix.jl
@@ -490,7 +490,7 @@ function list_tarball_symlinks(tarball_path::AbstractString; verbose::Bool = fal
     output = collect_stdout(oc)
 
     mm = [m.captures for m in eachmatch(gen_symlink_parser, output)]
-    symlinks = [m[1] => joinpath(splitdir(m[1])[1], split(m[2], "/")...) for m in mm]
+    symlinks = [m[1] => joinpath(dirname(m[1]), m[2]) for m in mm]
     return symlinks
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -405,7 +405,7 @@ end
 	bin/
 	bin/socrates
 	"""
-	@test parse_tar_list(fake_tar_output) == ["bin/socrates"]
+	@test parse_tar_list(fake_tar_output) == normpath.(["bin/socrates"])
 
 end
 


### PR DESCRIPTION
- modified tar commands for backward compatibility (e.g. busybox 1.24.1, see https://github.com/JuliaPackaging/BinaryProvider.jl/issues/162) and other compression types
- `parse_tar_list` on windows returns windows paths
- `busybox tar`and `tar` work successfully on Windows 10 if compression tools are installed (bzip)

Please comment, whether this sounds reasonable to you