### PR TITLE
fix a line of code which causes CodecLibz build to fail

### DIFF
--- a/src/Products.jl
+++ b/src/Products.jl
@@ -166,7 +166,7 @@ function locate(lp::LibraryProduct; verbose::Bool = false,
                     if isolate
                         # Isolated dlopen is a lot slower, but safer
                         dl_esc_path = replace(dl_path, "\\"=>"\\\\")
-                        if success(`$(Base.julia_cmd()) -e "import Libdl; Libdl.dlopen(\"$(dl_esc_path)\")"`)
+                        if Libdl.dlopen(dl_esc_path) != nothing
                             return dl_path
                         end
                     else


### PR DESCRIPTION
Got this error while building CodecLibz:

```
│ ERROR: LoadError: LibraryProduct(nothing, ["libz"], :libz, "Prefix(/home/kaiyin/.julia/packages/CodecZlib/hJvUf/deps/usr)") is not satisfied, cannot generate deps.jl!
```

This commit fixes the problem. 