### PR TITLE
leaving the quoting up to the `success` command

### DIFF
--- a/src/Products.jl
+++ b/src/Products.jl
@@ -166,7 +166,8 @@ function locate(lp::LibraryProduct; verbose::Bool = false,
                     if isolate
                         # Isolated dlopen is a lot slower, but safer
                         dl_esc_path = replace(dl_path, "\\"=>"\\\\")
-                        if success(`$(Base.julia_cmd()) -e "import Libdl; Libdl.dlopen(\"$(dl_esc_path)\")"`)
+                        script = """import Libdl; Libdl.dlopen("$(dl_esc_path)")"""
+                        if success(`$(Base.julia_cmd()) -e $script`)
                             return dl_path
                         end
                     else


### PR DESCRIPTION
Maybe, the problem on some machines comes from different usage of quotes in different environments.
I propose to first define the julia script and have the quoting done by the underlying `run` command of `success`.
@davidanthoff thanks for your input. I didn't have a computer at hand to test, that's why I was asking for your help.
As David kindly prooved, powershell and cmd need different quotation marks. (Maybe different systems are using different backends? - Well I am speculating ...)
@davidanthoff could you test this version? At least for me it doesn't break things.

EDIT:
This PR refers to the issues #170 and #172 and https://github.com/Nemocas/Nemo.jl/issues/600