### PR TITLE
default to /usr/bin/curl on macOS

### DIFF
--- a/src/PlatformEngines.jl
+++ b/src/PlatformEngines.jl
@@ -180,6 +180,7 @@ function probe_platform_engines!(;verbose::Bool = false)
         (`fetch --help`, (url, path) -> `fetch --user-agent=$agent -f $path $url`),
         (`busybox wget --help`, (url, path) -> `busybox wget -U $agent -c -O $path $url`),
     ]
+    Sys.isapple() && pushfirst!(download_engines, (`/usr/bin/curl --help`, (url, path) -> `/usr/bin/curl -H "User-Agent: $agent" -C - -\# -f -o $path -L $url`))
 
     # 7z is rather intensely verbose.  We also want to try running not only
     # `7z` but also a direct path to the `7z.exe` bundled with Julia on


### PR DESCRIPTION
Same as https://github.com/JuliaLang/julia/pull/30969, for the same reason.   

(I just encountered a student who had a broken `curl` in his PATH on MacOS and it broke BinaryProvider.)

Eventually we should have a single `download` function (https://github.com/JuliaLang/julia/issues/27043), but in the meantime we'll need to manually check that `BinaryProvider.download_cmd` is at least as functional as `Base.download`.