### PR TITLE
Fix isolated dlopen

### DIFF
--- a/src/Products.jl
+++ b/src/Products.jl
@@ -166,7 +166,7 @@ function locate(lp::LibraryProduct; verbose::Bool = false,
                     if isolate
                         # Isolated dlopen is a lot slower, but safer
                         dl_esc_path = replace(dl_path, "\\"=>"\\\\")
-                        if success(`$(Base.julia_cmd()) -e "import Libdl; Libdl.dlopen(\"$(dl_esc_path)\")"`)
+                        if success(`$(Base.julia_cmd()) --startup-file=no -e "import Libdl; Libdl.dlopen(\"$(dl_esc_path)\")"`)
                             return dl_path
                         end
                     else


### PR DESCRIPTION
In `locate`, when launching an external Julia to test whether dlopen work
on a library, pass `--startup-file=no` to the subprocess to avoid any issues
with commands in a user's startup.jl file.

Fixes #194

On master, this was already fixed by PR #189 -- if you prefer, I can also turn this into a cherry-pick of 81f03dad25dfd76845f4fbc0eea1a383280f334c


It would be great if a new release of BinaryProvider.jl with this fix could be made soon. Perhaps first wait if others can reproduce the issue and the fix. For me, the culprit was this:
```
$ cat .julia/config/startup.jl
using InteractiveUtils
if isdefined(InteractiveUtils, :define_editor)
    InteractiveUtils.define_editor("bbedit") do cmd, path, line
       `$cmd $path:$line`
    end
end
```

See also https://github.com/JuliaPackaging/BinaryBuilder.jl/pull/793