### PR TITLE
Stricter regex patterns in parse_dl_name_version

### DIFF
--- a/src/PlatformNames.jl
+++ b/src/PlatformNames.jl
@@ -500,11 +500,11 @@ returns `"libbar", nothing`.
 function parse_dl_name_version(path::AbstractString, platform::Platform)
     dlext_regexes = Dict(
         # On Linux, libraries look like `libnettle.so.6.3.0`
-        "so" => r"^(.*?).so((?:\.[\d]+)*)$",
+        "so" => r"^(.*?)\.so((?:\.[\d]+)*)$",
         # On OSX, libraries look like `libnettle.6.3.dylib`
-        "dylib" => r"^(.*?)((?:\.[\d]+)*).dylib$",
+        "dylib" => r"^(.*?)((?:\.[\d]+)*)\.dylib$",
         # On Windows, libraries look like `libnettle-6.dylib`
-        "dll" => r"^(.*?)(?:-((?:[\.\d]+)*))?.dll$"
+        "dll" => r"^(.*?)(?:-((?:[\.\d]+)*))?\.dll$"
     )
 
     # Use the regex that matches this platform


### PR DESCRIPTION
Instead of `.so` (i.e., any character followed by "so") match `\.` (i.e., a dot followed by "so").

I hope (but have not try to verified) that this will fix https://github.com/JuliaPackaging/BinaryBuilder.jl/issues/857