### PR TITLE
Make BinaryProvider not crash during loading in case the platform is known

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BinaryProvider"
 uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
-version = "0.5.10"
+version = "0.5.11"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/src/PlatformNames.jl
+++ b/src/PlatformNames.jl
@@ -548,6 +548,9 @@ Examines the given libgfortran SONAME to see what version of GCC corresponds
 to the given libgfortran version.
 """
 function detect_libgfortran_abi(libgfortran_name::AbstractString, platform::Platform = platform_key_abi(Sys.MACHINE))
+    if platform isa UnknownPlatform
+      return :gcc_any
+    end
     # Extract the version number from this libgfortran.  Ironically, parse_dl_name_version()
     # wants a Platform, but we may not have initialized the default platform key yet when we
     # run this method for the first time (since we need the output of this function to set


### PR DESCRIPTION
Fixes the non-precompilability on julia >= 1.7.