### PR TITLE
Create `global_prefix` inside the JULIA_DEPOT as a fallback

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BinaryProvider"
 uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
-version = "0.6.0"
+version = "0.6.1"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/src/BinaryProvider.jl
+++ b/src/BinaryProvider.jl
@@ -33,7 +33,11 @@ function __init__()
     global global_prefix
 
     # Initialize our global_prefix
-    global_prefix = Prefix(joinpath(@__DIR__, "..", "global_prefix"))
+     try
+        global_prefix = Prefix(joinpath(@__DIR__, "..", "global_prefix"))
+    catch e
+        global_prefix = Prefix(joinpath(Pkg.depots1(), "global_prefix"))
+    end
 
     # Find the right download/compression engines for this platform
     probe_platform_engines!()


### PR DESCRIPTION
- While using this package inside docker, the initialization of sysimage failed as the permission was denied to create a access  `@__DIR__/..`
- So in such cases creating a global_prefix in JULIA_DEPOT is useful