### PR TITLE
Fix install function

### DIFF
--- a/src/BinaryProvider.jl
+++ b/src/BinaryProvider.jl
@@ -2,7 +2,7 @@ module BinaryProvider
 
 using Libdl, Logging
 using Pkg, Pkg.PlatformEngines, Pkg.BinaryPlatforms
-import Pkg.PlatformEngines: package, download
+import Pkg.PlatformEngines: package, download, download_verify, list_tarball_files
 import Pkg.BinaryPlatforms: Linux
 export platform_key, platform_key_abi, platform_dlext, valid_dl_path,
        triplet, select_platform, platforms_match,

--- a/src/Prefix.jl
+++ b/src/Prefix.jl
@@ -342,7 +342,10 @@ function install(tarball_url::AbstractString,
     end
 
     # Unpack the tarball into prefix
-    unpack(tarball_path, prefix.path; verbose=verbose)
+    t = tempname()
+    unpack(tarball_path, t; verbose=verbose)
+    foreach(f -> mv(joinpath(t, f), joinpath(prefix.path, f)), readdir(t))
+    rm(t, recursive = true)
 
     # Save installation manifest
     mkpath(dirname(manifest_path))


### PR DESCRIPTION
After #190, `install` was broken due to some missing imports. Also, the behaviour of `unpack` seems to have changed: it now errors when used this way, because the target directory is required to be empty. I've added an unzip to a temporary directory in order to replicate the old behaviour.

I haven't checked for other uses of `unpack`, which may also need fixing, or for other missing imports; this just fixes one particular build script I have.