### PR TITLE
Update to LTS and above versions of Julia

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,7 @@ task:
   name: FreeBSD
   env:
     matrix:
-      - JULIA_VERSION: 1.3
+      - JULIA_VERSION: 1.6
       - JULIA_VERSION: nightly
   install_script:
     - sh -c "$(fetch https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin/install.sh -o -)"

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 Tar = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 
 [compat]
-julia = "1.3"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+Tar = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 
 [compat]
 julia = "1.3"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   matrix:
-  - julia_version: 1.3
+  - julia_version: 1.6
   - julia_version: latest
 
 platform:

--- a/src/BinaryProvider.jl
+++ b/src/BinaryProvider.jl
@@ -1,19 +1,16 @@
 module BinaryProvider
 
-using Libdl, Logging
+using Libdl, Logging, Tar
 using Pkg, Pkg.PlatformEngines, Pkg.BinaryPlatforms
-import Pkg.PlatformEngines: package, download
-import Pkg.BinaryPlatforms: Linux
+import Pkg.PlatformEngines: package, download, download_verify
 export platform_key, platform_key_abi, platform_dlext, valid_dl_path,
        triplet, select_platform, platforms_match,
-       Linux, MacOS, Windows, FreeBSD,
        parse_7z_list, parse_tar_list, verify,
        download_verify, unpack, package, download_verify_unpack,
        list_tarball_files, list_tarball_symlinks
 
 # Some compatibility mapping
 const choose_download = Pkg.BinaryPlatforms.select_platform
-Linux(arch::Symbol, libc::Symbol) = Linux(arch; libc=libc)
 function platform_key(machine::AbstractString = Sys.MACHINE)
     Base.depwarn("platform_key() is deprecated, use platform_key_abi() from now on", :binaryprovider_platform_key)
     platkey = platform_key_abi(machine)

--- a/src/BinaryProvider.jl
+++ b/src/BinaryProvider.jl
@@ -34,9 +34,6 @@ function __init__()
 
     # Initialize our global_prefix
     global_prefix = Prefix(joinpath(@__DIR__, "..", "global_prefix"))
-
-    # Find the right download/compression engines for this platform
-    probe_platform_engines!()
 end
 
 # gotta go fast

--- a/src/Prefix.jl
+++ b/src/Prefix.jl
@@ -355,7 +355,8 @@ function install(tarball_url::AbstractString,
     end
 
     # Unpack the tarball into prefix
-    unpack(tarball_path, prefix.path; verbose=verbose)
+    redir_output = verbose ? stdout : devnull
+    run(pipeline(`$(Pkg.PlatformEngines.exe7z()) x $tarball_path -so`, `$(Pkg.PlatformEngines.exe7z()) x -si -aoa -ttar -o"$(prefix.path)"`, redir_output))
 
     # Save installation manifest
     mkpath(dirname(manifest_path))

--- a/src/Prefix.jl
+++ b/src/Prefix.jl
@@ -23,6 +23,19 @@ function safe_isfile(path)
 end
 
 """
+    list_tarball_files(tarball_path::AbstractString)
+
+    Given a .tar.gz filepath, list the compressed contents
+"""
+function list_tarball_files(tarball_path::AbstractString)
+    names = String[]
+    Tar.list(`$(Pkg.PlatformEngines.exe7z()) x $tarball_path -so`) do hdr
+        push!(names, hdr.path)
+    end
+    return names
+end
+
+"""
     temp_prefix(func::Function)
 
 Create a temporary prefix, passing the prefix into the user-defined function so

--- a/src/Products.jl
+++ b/src/Products.jl
@@ -260,7 +260,7 @@ function locate(ep::ExecutableProduct; platform::Platform = platform_key_abi(),
                 verbose::Bool = false, isolate::Bool = false)
     # On windows, we always slap an .exe onto the end if it doesn't already
     # exist, as Windows won't execute files that don't have a .exe at the end.
-    path = if platform isa Windows && !endswith(ep.path, ".exe")
+    path = if platform.tags["os"] == "windows" && !endswith(ep.path, ".exe")
         "$(ep.path).exe"
     else
         ep.path

--- a/test/LibFoo.jl/deps/build.jl
+++ b/test/LibFoo.jl/deps/build.jl
@@ -1,4 +1,4 @@
-using BinaryProvider
+using BinaryProvider, Pkg.BinaryPlatforms
 
 # Parse some basic command-line arguments
 const verbose = "--verbose" in ARGS
@@ -13,22 +13,22 @@ products = Product[
 # Download binaries from hosted location
 bin_prefix = "https://github.com/staticfloat/small_bin/raw/51b13b44feb2a262e2e04690bfa54d03167533f2/libfoo"
 download_info = Dict(
-    Linux(:aarch64; libc=:glibc) => ("$bin_prefix/libfoo.aarch64-linux-gnu.tar.gz", "36886ac25cf5678c01fe20630b413f9354b7a3721c6a2c2043162f7ebd147ff5"),
-    Linux(:armv7l; libc=:glibc)  => ("$bin_prefix/libfoo.arm-linux-gnueabihf.tar.gz", "147ebaeb1a722da43ee08705689aed71ac87c3c2c907af047c6721c0025ba383"),
-    Linux(:powerpc64le; libc=:glibc) => ("$bin_prefix/libfoo.powerpc64le-linux-gnu.tar.gz", "5c35295ac161272ada9a77d1f6b770e30ea864e521e31853258cbc36ad4c4468"),
-    Linux(:i686; libc=:glibc)    => ("$bin_prefix/libfoo.i686-linux-gnu.tar.gz", "97655b6a218d61284723b6923d7c96e6a256fa68b9419d723c588aa24404b102"),
-    Linux(:x86_64; libc=:glibc)  => ("$bin_prefix/libfoo.x86_64-linux-gnu.tar.gz", "5208c63a9d07e592c78f541fc13caa8cd191b11e7e77b31d407237c2b13ec391"),
+    Platform("aarch64", "linux"; libc="glibc") => ("$bin_prefix/libfoo.aarch64-linux-gnu.tar.gz", "36886ac25cf5678c01fe20630b413f9354b7a3721c6a2c2043162f7ebd147ff5"),
+    Platform("armv7l", "linux"; libc="glibc")  => ("$bin_prefix/libfoo.arm-linux-gnueabihf.tar.gz", "147ebaeb1a722da43ee08705689aed71ac87c3c2c907af047c6721c0025ba383"),
+    Platform("powerpc64le", "linux"; libc="glibc") => ("$bin_prefix/libfoo.powerpc64le-linux-gnu.tar.gz", "5c35295ac161272ada9a77d1f6b770e30ea864e521e31853258cbc36ad4c4468"),
+    Platform("i686", "linux"; libc="glibc")    => ("$bin_prefix/libfoo.i686-linux-gnu.tar.gz", "97655b6a218d61284723b6923d7c96e6a256fa68b9419d723c588aa24404b102"),
+    Platform("x86_64", "linux"; libc="glibc")  => ("$bin_prefix/libfoo.x86_64-linux-gnu.tar.gz", "5208c63a9d07e592c78f541fc13caa8cd191b11e7e77b31d407237c2b13ec391"),
 
-    Linux(:aarch64; libc=:musl)  => ("$bin_prefix/libfoo.aarch64-linux-musl.tar.gz", "81751477c1e3ee6c93e1c28ee7db2b99d1eed0d6ce86dc30d64c2e5dd4dfe88d"),
-    Linux(:armv7l; libc=:musl)   => ("$bin_prefix/libfoo.arm-linux-musleabihf.tar.gz", "bb65aad58f2e6fc39dc9688da1bca5e8103a3a3fa67dc589debbd2e98176f0e1"),
-    Linux(:i686; libc=:musl)     => ("$bin_prefix/libfoo.i686-linux-musl.tar.gz", "5f02fd1fe19f3a565fb128d3673b35c7b3214a101cef9dcbb202c0092438a87b"),
-    Linux(:x86_64; libc=:musl)   => ("$bin_prefix/libfoo.x86_64-linux-musl.tar.gz", "ea630600a12d2c1846bc93bcc8d9638a4991f63329205c534d93e0a3de5f641d"),
+    Platform("aarch64", "linux"; libc="musl")  => ("$bin_prefix/libfoo.aarch64-linux-musl.tar.gz", "81751477c1e3ee6c93e1c28ee7db2b99d1eed0d6ce86dc30d64c2e5dd4dfe88d"),
+    Platform("armv7l", "linux"; libc="musl")   => ("$bin_prefix/libfoo.arm-linux-musleabihf.tar.gz", "bb65aad58f2e6fc39dc9688da1bca5e8103a3a3fa67dc589debbd2e98176f0e1"),
+    Platform("i686", "linux"; libc="musl")     => ("$bin_prefix/libfoo.i686-linux-musl.tar.gz", "5f02fd1fe19f3a565fb128d3673b35c7b3214a101cef9dcbb202c0092438a87b"),
+    Platform("x86_64", "linux"; libc="musl")   => ("$bin_prefix/libfoo.x86_64-linux-musl.tar.gz", "ea630600a12d2c1846bc93bcc8d9638a4991f63329205c534d93e0a3de5f641d"),
 
-    FreeBSD(:x86_64)        => ("$bin_prefix/libfoo.x86_64-unknown-freebsd11.1.tar.gz", "5f6edd6247b3685fa5c42c98a53d2a3e1eef6242c2bb3cdbb5fe23f538703fe4"),
-    MacOS(:x86_64)          => ("$bin_prefix/libfoo.x86_64-apple-darwin14.tar.gz", "fcc268772d6f21d65b45fcf3854a3142679b78e53c7673dac26c95d6ccc89a24"),
+    Platform("x86_64", "freebsd")        => ("$bin_prefix/libfoo.x86_64-unknown-freebsd11.1.tar.gz", "5f6edd6247b3685fa5c42c98a53d2a3e1eef6242c2bb3cdbb5fe23f538703fe4"),
+    Platform("x86_64", "macos")          => ("$bin_prefix/libfoo.x86_64-apple-darwin14.tar.gz", "fcc268772d6f21d65b45fcf3854a3142679b78e53c7673dac26c95d6ccc89a24"),
 
-    Windows(:i686)          => ("$bin_prefix/libfoo.i686-w64-mingw32.tar.gz", "79181cf62ca8e0b2e0851fa0ace52f4ab335d0cad26fb7f9cd4ff356a9a96e70"),
-    Windows(:x86_64)        => ("$bin_prefix/libfoo.x86_64-w64-mingw32.tar.gz", "7f8939e9529835b83810d3ae7e2556f6e002d571f619894e54ece42ea5262b7f"),
+    Platform("i686", "windows")          => ("$bin_prefix/libfoo.i686-w64-mingw32.tar.gz", "79181cf62ca8e0b2e0851fa0ace52f4ab335d0cad26fb7f9cd4ff356a9a96e70"),
+    Platform("x86_64", "windows")        => ("$bin_prefix/libfoo.x86_64-w64-mingw32.tar.gz", "7f8939e9529835b83810d3ae7e2556f6e002d571f619894e54ece42ea5262b7f"),
 )
 # First, check to see if we're all satisfied
 if any(!satisfied(p; verbose=verbose) for p in products)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,8 @@
 using BinaryProvider
 using Test
 using Libdl
-using Pkg
+using Pkg, Pkg.BinaryPlatforms, Pkg.PlatformEngines
 using SHA
-using Pkg.BinaryPlatforms
 
 # The platform we're running on
 const platform = platform_key_abi()
@@ -395,8 +394,9 @@ end
 
     # Install it within a new Prefix
     temp_prefix() do prefix
+        prefix = Prefix("global_prefix")
         # Install the thing
-        @test install(tarball_path, tarball_hash; prefix=prefix, verbose=true)
+        @test install(tarball_path, tarball_hash; prefix=prefix, verbose=true, force=true)
 
         # Ensure we can use it
         bar_path = joinpath(bindir(prefix), "bar.sh")
@@ -450,7 +450,7 @@ end
         # Ensure that hash mismatches log errors
         fake_hash = reverse(tarball_hash)
         @test_logs (:error, r"Hash Mismatch") match_mode=:any begin
-            install(tarball_path, fake_hash; prefix=prefix)
+            install(tarball_path, fake_hash; prefix=prefix, force=true)
         end
     end
 
@@ -474,8 +474,8 @@ end
 
     # Next, check installing with a bogus platform also fails, but can be forced
     temp_prefix() do prefix
-        @test_throws ArgumentError install(bogus_tarball_path, tarball_hash; prefix=prefix, verbose=true)
-        @test install(bogus_tarball_path, tarball_hash; prefix=prefix, verbose=true, ignore_platform = true)
+        @test_throws ArgumentError install(bogus_tarball_path, tarball_hash; prefix=prefix, verbose=true, force=true)
+        @test install(bogus_tarball_path, tarball_hash; prefix=prefix, verbose=true, ignore_platform = true, force=true)
     end
 
     # Cleanup after ourselves

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using Test
 using Libdl
 using Pkg
 using SHA
+using Pkg.BinaryPlatforms
 
 # The platform we're running on
 const platform = platform_key_abi()
@@ -28,6 +29,7 @@ end
 
 @testset "OutputCollector" begin
     cd("output_tests") do
+        @info pwd()
         # Collect the output of `simple.sh``
         oc = OutputCollector(`$sh ./simple.sh`)
 
@@ -191,8 +193,8 @@ end
         end
 
         # Test that we can control libdir() via platform arguments
-        @test libdir(prefix, Linux(:x86_64)) == joinpath(prefix, "lib")
-        @test libdir(prefix, Windows(:x86_64)) == joinpath(prefix, "bin")
+        @test libdir(prefix, Platform("x86_64", "linux")) == joinpath(prefix, "lib")
+        @test libdir(prefix, Platform("x86_64", "windows")) == joinpath(prefix, "bin")
     end
 end
 
@@ -220,19 +222,19 @@ end
         @test satisfied(ef, verbose=true)
         @static if !Sys.iswindows()
             # Windows doesn't care about executable bit, grumble grumble
-            @test !satisfied(e, verbose=true, platform=Linux(:x86_64))
+            @test !satisfied(e, verbose=true, platform=Platform("x86_64", "linux"))
         end
 
         # Make it executable and ensure this does satisfy the Executable
         chmod(e_path, 0o777)
-        @test satisfied(e, verbose=true, platform=Linux(:x86_64))
+        @test satisfied(e, verbose=true, platform=Platform("x86_64", "linux"))
 
         # Remove it and add a `$(path).exe` version to check again, this
         # time saying it's a Windows executable
         Base.rm(e_path; force=true)
         touch("$(e_path).exe")
         chmod("$(e_path).exe", 0o777)
-        @test locate(e, platform=Windows(:x86_64)) == "$(e_path).exe"
+        @test locate(e, platform=Platform("x86_64", "windows")) == "$(e_path).exe"
 
         # Test that simply creating a library file doesn't satisfy it if we are
         # testing something that matches the current platform's dynamic library
@@ -247,7 +249,7 @@ end
         # But if it is from a different platform, simple existence will be
         # enough to satisfy a LibraryProduct
         @static if Sys.iswindows()
-            p = Linux(:x86_64)
+            p = Platform("x86_64", "linux")
             mkpath(libdir(prefix, p))
             l_path = joinpath(libdir(prefix, p), "libfoo.so")
             touch(l_path)
@@ -259,7 +261,7 @@ end
             @test satisfied(ld, verbose=true, platform=p)
             @test satisfied(ld, verbose=true, platform=p, isolate=true)
         else
-            p = Windows(:x86_64)
+            p = Platform("x86_64", "windows")
             mkpath(libdir(prefix, p))
             l_path = joinpath(libdir(prefix, p), "libfoo.dll")
             touch(l_path)
@@ -275,12 +277,12 @@ end
 
     # Ensure that the test suite thinks that these libraries are foreign
     # so that it doesn't try to `dlopen()` them:
-    foreign_platform = if platform == Linux(:aarch64)
+    foreign_platform = if platform == Platform("aarch64", "linux")
         # Arbitrary architecture that is not dlopen()'able
-        Linux(:powerpc64le)
+        Platform("powerpc64le", "linux")
     else
-        # If we're not Linux(:aarch64), then say the libraries are
-        Linux(:aarch64)
+        # If we're not Platform("aarch64", "linux")), then say the libraries are
+        Platform("aarch64", "linux")
     end
 
     # Test for valid library name permutations
@@ -453,8 +455,8 @@ end
     end
 
     # Get a valid platform tarball name that is not our native platform
-    other_platform = Linux(:x86_64)
-    if BinaryProvider.platforms_match(platform, Linux(:x86_64))
+    other_platform = Platform("x86_64", "linux")
+    if BinaryProvider.platforms_match(platform, Platform("x86_64", "linux"))
         other_platform = MacOS()
     end
     new_tarball_path = "libfoo.v1.0.0.$(triplet(other_platform)).tar.gz"
@@ -593,22 +595,22 @@ end
 # Use `build_libfoo_tarball.jl` in the BinaryBuilder.jl repository to generate more of these
 const bin_prefix = "https://github.com/staticfloat/small_bin/raw/51b13b44feb2a262e2e04690bfa54d03167533f2/libfoo"
 const libfoo_downloads = Dict(
-    Linux(:aarch64; libc=:glibc) => ("$bin_prefix/libfoo.aarch64-linux-gnu.tar.gz", "36886ac25cf5678c01fe20630b413f9354b7a3721c6a2c2043162f7ebd147ff5"),
-    Linux(:armv7l; libc=:glibc)  => ("$bin_prefix/libfoo.arm-linux-gnueabihf.tar.gz", "147ebaeb1a722da43ee08705689aed71ac87c3c2c907af047c6721c0025ba383"),
-    Linux(:powerpc64le; libc=:glibc) => ("$bin_prefix/libfoo.powerpc64le-linux-gnu.tar.gz", "5c35295ac161272ada9a77d1f6b770e30ea864e521e31853258cbc36ad4c4468"),
-    Linux(:i686; libc=:glibc)    => ("$bin_prefix/libfoo.i686-linux-gnu.tar.gz", "97655b6a218d61284723b6923d7c96e6a256fa68b9419d723c588aa24404b102"),
-    Linux(:x86_64; libc=:glibc)  => ("$bin_prefix/libfoo.x86_64-linux-gnu.tar.gz", "5208c63a9d07e592c78f541fc13caa8cd191b11e7e77b31d407237c2b13ec391"),
+    Platform("aarch64", "linux"; libc="glibc")     => ("$bin_prefix/libfoo.aarch64-linux-gnu.tar.gz", "36886ac25cf5678c01fe20630b413f9354b7a3721c6a2c2043162f7ebd147ff5"),
+    Platform("armv7l", "linux"; libc="glibc")      => ("$bin_prefix/libfoo.arm-linux-gnueabihf.tar.gz", "147ebaeb1a722da43ee08705689aed71ac87c3c2c907af047c6721c0025ba383"),
+    Platform("powerpc64le", "linux"; libc="glibc") => ("$bin_prefix/libfoo.powerpc64le-linux-gnu.tar.gz", "5c35295ac161272ada9a77d1f6b770e30ea864e521e31853258cbc36ad4c4468"),
+    Platform("i686", "linux"; libc="glibc")        => ("$bin_prefix/libfoo.i686-linux-gnu.tar.gz", "97655b6a218d61284723b6923d7c96e6a256fa68b9419d723c588aa24404b102"),
+    Platform("x86_64", "linux"; libc="glibc")      => ("$bin_prefix/libfoo.x86_64-linux-gnu.tar.gz", "5208c63a9d07e592c78f541fc13caa8cd191b11e7e77b31d407237c2b13ec391"),
 
-    Linux(:aarch64; libc=:musl)  => ("$bin_prefix/libfoo.aarch64-linux-musl.tar.gz", "81751477c1e3ee6c93e1c28ee7db2b99d1eed0d6ce86dc30d64c2e5dd4dfe88d"),
-    Linux(:armv7l; libc=:musl)   => ("$bin_prefix/libfoo.arm-linux-musleabihf.tar.gz", "bb65aad58f2e6fc39dc9688da1bca5e8103a3a3fa67dc589debbd2e98176f0e1"),
-    Linux(:i686; libc=:musl)     => ("$bin_prefix/libfoo.i686-linux-musl.tar.gz", "5f02fd1fe19f3a565fb128d3673b35c7b3214a101cef9dcbb202c0092438a87b"),
-    Linux(:x86_64; libc=:musl)   => ("$bin_prefix/libfoo.x86_64-linux-musl.tar.gz", "ea630600a12d2c1846bc93bcc8d9638a4991f63329205c534d93e0a3de5f641d"),
+    Platform("aarch64", "linux"; libc="musl")  => ("$bin_prefix/libfoo.aarch64-linux-musl.tar.gz", "81751477c1e3ee6c93e1c28ee7db2b99d1eed0d6ce86dc30d64c2e5dd4dfe88d"),
+    Platform("armv7l", "linux"; libc="musl")   => ("$bin_prefix/libfoo.arm-linux-musleabihf.tar.gz", "bb65aad58f2e6fc39dc9688da1bca5e8103a3a3fa67dc589debbd2e98176f0e1"),
+    Platform("i686", "linux"; libc="musl")     => ("$bin_prefix/libfoo.i686-linux-musl.tar.gz", "5f02fd1fe19f3a565fb128d3673b35c7b3214a101cef9dcbb202c0092438a87b"),
+    Platform("x86_64", "linux"; libc="musl")   => ("$bin_prefix/libfoo.x86_64-linux-musl.tar.gz", "ea630600a12d2c1846bc93bcc8d9638a4991f63329205c534d93e0a3de5f641d"),
 
-    FreeBSD(:x86_64)        => ("$bin_prefix/libfoo.x86_64-unknown-freebsd11.1.tar.gz", "5f6edd6247b3685fa5c42c98a53d2a3e1eef6242c2bb3cdbb5fe23f538703fe4"),
-    MacOS(:x86_64)          => ("$bin_prefix/libfoo.x86_64-apple-darwin14.tar.gz", "fcc268772d6f21d65b45fcf3854a3142679b78e53c7673dac26c95d6ccc89a24"),
+    Platform("x86_64", "freebsd") => ("$bin_prefix/libfoo.x86_64-unknown-freebsd11.1.tar.gz", "5f6edd6247b3685fa5c42c98a53d2a3e1eef6242c2bb3cdbb5fe23f538703fe4"),
+    Platform("x86_64", "macos")   => ("$bin_prefix/libfoo.x86_64-apple-darwin14.tar.gz", "fcc268772d6f21d65b45fcf3854a3142679b78e53c7673dac26c95d6ccc89a24"),
 
-    Windows(:i686)          => ("$bin_prefix/libfoo.i686-w64-mingw32.tar.gz", "79181cf62ca8e0b2e0851fa0ace52f4ab335d0cad26fb7f9cd4ff356a9a96e70"),
-    Windows(:x86_64)        => ("$bin_prefix/libfoo.x86_64-w64-mingw32.tar.gz", "7f8939e9529835b83810d3ae7e2556f6e002d571f619894e54ece42ea5262b7f"),
+    Platform("i686", "windows")   => ("$bin_prefix/libfoo.i686-w64-mingw32.tar.gz", "79181cf62ca8e0b2e0851fa0ace52f4ab335d0cad26fb7f9cd4ff356a9a96e70"),
+    Platform("x86_64", "windows") => ("$bin_prefix/libfoo.x86_64-w64-mingw32.tar.gz", "7f8939e9529835b83810d3ae7e2556f6e002d571f619894e54ece42ea5262b7f"),
 )
 
 # Test manually downloading and using libfoo

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,10 +12,6 @@ const simple_out = "1\n2\n3\n4\n"
 const long_out = join(["$(idx)\n" for idx in 1:100], "")
 const newlines_out = join(["marco$(d)polo$(d)" for d in ("\n","\r","\r\n")], "")
 
-# Explicitly probe platform engines in verbose mode to get coverage and make
-# CI debugging easier
-BinaryProvider.probe_platform_engines!(;verbose=true)
-
 # shell executable for testing
 sh = "sh"
 


### PR DESCRIPTION
- Fixes the package for Julia-1.8 and above
- The Pkg#release-1.8 has dropped the function from PlatformEngines.jl
- It "didn't do anything" even in release-1.7 (see [here](https://github.com/JuliaLang/Pkg.jl/blob/release-1.7/src/PlatformEngines.jl#L44))
- Perhaps this function can be dropped here as well
~- Depends on #212 for CI to run~